### PR TITLE
Update activity #12: help defining an activity that executes a program

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ python:
 
 install: pip install -U .
 
-script: py.test
+script: py.test -vv

--- a/docs/execute.rst
+++ b/docs/execute.rst
@@ -1,0 +1,58 @@
+.. _execute:
+
+Execution of Tasks as Programs
+==============================
+
+Introduction
+-------------
+
+The :py:mod:`simpleflow.execute` module allows to define functions that will be
+executed as a program.
+
+There are two modes:
+
+- Convert the definition of a fonction as a command line.
+- Execute a Python function in another process.
+
+Please refer to the :py:mod:`simpleflow.tests.test_activity` test module for
+further examples.
+
+Executing a function as a command line
+--------------------------------------
+
+Let's take the example of ``ls``:
+
+.. code::
+
+        @execute.program()
+        def ls():
+            pass
+
+Calling ``ls()`` in Python will execute the ``ls`` command. Here the purpose of
+the function definition is only to describe the command line. The reason for
+this is to map a call in a workflow definition to a program to execute on the
+command line. The program may be written in any language whereas the workflow
+definition is in Python.
+
+Executing a Python function in another process
+----------------------------------------------
+
+The rationale for this feature is to execute a function with another
+interpreter (such as pypy) or in another environment (virtualenv).
+
+.. code::
+
+    @execute.python(interpreter='pypy')
+    def inc(xs):
+        return [x + 1 for x in xs]
+
+Calling ``inc(range(10))`` in Python will execute the function with the
+``pypy`` interpreter found in the ``$PATH``.
+
+
+Limitations
+-----------
+
+The main limitation comes from the need to serialize the arguments and the
+return values to pass them as strings. Hence all arguments and return values
+must be convertible into JSON values.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Guide
    license
    install
    quickstart
+   execute
    api_reference
 
 Project info

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     package_dir={'simpleflow': 'simpleflow'},
     include_package_data=True,
     install_requires=[
-        'simple-workflow>=0.1.46',
+        'simple-workflow>=0.1.47',
     ],
     license=read("LICENSE"),
     zip_safe=False,

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -1,7 +1,3 @@
-import functools
-import inspect
-import subprocess
-
 from . import task
 
 
@@ -32,76 +28,6 @@ def with_attributes(name=None, version=None, task_list=None,
         )
 
     return wrap
-
-
-class RequiredArgument(object):
-    pass
-
-
-def format_arguments(*args, **kwargs):
-    """
-    Examples:
-
-        >>> format_arguments('a', 'b', c=1, d=2)
-        ['--c=1', '--d=2', 'a', 'b']
-
-    """
-    return ['--{}="{}"'.format(key, value) for key, value in
-            kwargs.iteritems()] + map(str, args)
-
-
-def zip_arguments_defaults(argspec):
-    if not argspec.defaults:
-        return []
-
-    return zip(
-        argspec.args[-len(argspec.defaults):],
-        argspec.defaults)
-
-
-def check_arguments(argspec, args):
-    # func() or func(**kwargs) or func(a=1, b=2)
-    if not argspec.varargs and not argspec.args and args:
-        raise TypeError('command does not take varargs')
-
-    # Calling func(a, b) with func(1, 2, 3)
-    if (not argspec.varargs and argspec.args and
-            len(args) != len(argspec.args)):
-        raise TypeError('command takes {} arguments: {} passed'.format(
-            len(argspec.args),
-            len(args)))
-
-
-def check_keyword_arguments(argspec, kwargs):
-    # func() or func(*args) or func(a, b)
-    if not argspec.keywords and not argspec.defaults and kwargs:
-        raise TypeError('command does not take keyword arguments')
-
-    arguments_defaults = zip_arguments_defaults(argspec)
-    not_found = (set(name for name, value in arguments_defaults if
-                     value is RequiredArgument) -
-                 set(kwargs))
-    # Calling func(a=1, b) with func(2) instead of func(a=0, 2)
-    if not_found:
-        raise TypeError('argument{} "{}" not found'.format(
-            's' if len(not_found) > 1 else '',
-            ', '.join(not_found)))
-
-
-def execute_program(path=None, argument_format=format_arguments):
-    def wrap_callable(func):
-        @functools.wraps(func)
-        def execute(*args, **kwargs):
-            check_arguments(argspec, args)
-            check_keyword_arguments(argspec, kwargs)
-
-            command = path or func.func_name
-            return subprocess.check_output(
-                [command] + argument_format(*args, **kwargs))
-
-        argspec = inspect.getargspec(func)
-        return execute
-    return wrap_callable
 
 
 class Activity(object):

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -1,3 +1,7 @@
+import functools
+import inspect
+import subprocess
+
 from . import task
 
 
@@ -28,6 +32,76 @@ def with_attributes(name=None, version=None, task_list=None,
         )
 
     return wrap
+
+
+class RequiredArgument(object):
+    pass
+
+
+def format_arguments(*args, **kwargs):
+    """
+    Examples:
+
+        >>> format_arguments('a', 'b', c=1, d=2)
+        ['--c=1', '--d=2', 'a', 'b']
+
+    """
+    return ['--{}="{}"'.format(key, value) for key, value in
+            kwargs.iteritems()] + map(str, args)
+
+
+def zip_arguments_defaults(argspec):
+    if not argspec.defaults:
+        return []
+
+    return zip(
+        argspec.args[-len(argspec.defaults):],
+        argspec.defaults)
+
+
+def check_arguments(argspec, args):
+    # func() or func(**kwargs) or func(a=1, b=2)
+    if not argspec.varargs and not argspec.args and args:
+        raise TypeError('command does not take varargs')
+
+    # Calling func(a, b) with func(1, 2, 3)
+    if (not argspec.varargs and argspec.args and
+            len(args) != len(argspec.args)):
+        raise TypeError('command takes {} arguments: {} passed'.format(
+            len(argspec.args),
+            len(args)))
+
+
+def check_keyword_arguments(argspec, kwargs):
+    # func() or func(*args) or func(a, b)
+    if not argspec.keywords and not argspec.defaults and kwargs:
+        raise TypeError('command does not take keyword arguments')
+
+    arguments_defaults = zip_arguments_defaults(argspec)
+    not_found = (set(name for name, value in arguments_defaults if
+                     value is RequiredArgument) -
+                 set(kwargs))
+    # Calling func(a=1, b) with func(2) instead of func(a=0, 2)
+    if not_found:
+        raise TypeError('argument{} "{}" not found'.format(
+            's' if len(not_found) > 1 else '',
+            ', '.join(not_found)))
+
+
+def execute_program(path=None, argument_format=format_arguments):
+    def wrap_callable(func):
+        @functools.wraps(func)
+        def execute(*args, **kwargs):
+            check_arguments(argspec, args)
+            check_keyword_arguments(argspec, kwargs)
+
+            command = path or func.func_name
+            return subprocess.check_output(
+                [command] + argument_format(*args, **kwargs))
+
+        argspec = inspect.getargspec(func)
+        return execute
+    return wrap_callable
 
 
 class Activity(object):

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -46,7 +46,7 @@ class TaskFailed(Exception):
 
 
 class TimeoutError(Exception):
-    def __init__(self, timeout_type, timeout_value=None):
+    def __init__(self, timeout_type='unknown timeout', timeout_value=None):
         self.timeout_type = timeout_type
         self.timeout_value = timeout_value
 

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -1,0 +1,337 @@
+import sys
+import subprocess
+import functools
+import json
+import cPickle as pickle
+import base64
+
+
+__all__ = ['program', 'python']
+
+
+class RequiredArgument(object):
+    pass
+
+
+def format_arguments(*args, **kwargs):
+    """
+    Returns a string that contains the values of *args* and *kwargs* as command
+    line options.
+
+    :param args: that can be converted to strings.
+    :type  args: tuple.
+    :param kwargs: whose keys and values can be converted to strings.
+    :type  kwargs: dict.
+
+    :returns:
+        :rtype: str.
+
+    The elements args must be convertible to strings and will be used as
+    positional arguments.
+
+    The items of *kwargs* are translated to key/value options (-c=1). Their
+    format follows the convention of one hyphen for short options (-c) and two
+    hyphens for long options (--val).
+
+    Examples:
+
+        >>> format_arguments('a', 'b', c=1, val=2)
+        ['-c=1', '--val=2', 'a', 'b']
+
+    """
+    def arg(key):
+        if len(key) == 1:
+            return '-' + str(key)  # short option -c
+        return '--' + str(key)     # long option --val
+
+    return ['{}="{}"'.format(arg(key), value) for key, value in
+            kwargs.iteritems()] + map(str, args)
+
+
+def zip_arguments_defaults(argspec):
+    if not argspec.defaults:
+        return []
+
+    return zip(
+        argspec.args[-len(argspec.defaults):],
+        argspec.defaults)
+
+
+def check_arguments(argspec, args):
+    """Validates there is the right number of arguments"""
+    # func() or func(**kwargs) or func(a=1, b=2)
+    if not argspec.varargs and not argspec.args and args:
+        raise TypeError('command does not take varargs')
+
+    # Calling func(a, b) with func(1, 2, 3)
+    if (not argspec.varargs and argspec.args and
+            len(args) != len(argspec.args)):
+        raise TypeError('command takes {} arguments: {} passed'.format(
+            len(argspec.args),
+            len(args)))
+
+
+def check_keyword_arguments(argspec, kwargs):
+    # func() or func(*args) or func(a, b)
+    if not argspec.keywords and not argspec.defaults and kwargs:
+        raise TypeError('command does not take keyword arguments')
+
+    arguments_defaults = zip_arguments_defaults(argspec)
+    not_found = (set(name for name, value in arguments_defaults if
+                     value is RequiredArgument) -
+                 set(kwargs))
+    # Calling func(a=1, b) with func(2) instead of func(a=0, 2)
+    if not_found:
+        raise TypeError('argument{} "{}" not found'.format(
+            's' if len(not_found) > 1 else '',
+            ', '.join(not_found)))
+
+
+def format_arguments_json(*args, **kwargs):
+    return json.dumps({
+        'args': args,
+        'kwargs': kwargs,
+    })
+
+
+def get_name(func):
+    """
+    Returns the name of a callable.
+
+    It handles different types of callable: function, callable object with
+    ``__call__`` method and callable objects that provide their name in the
+    ``name`` attributes.
+
+    :type func: callable.
+    :returns:
+        :rtype: str.
+
+    """
+    import types
+
+    prefix = func.__module__
+
+    if not callable(func):
+        raise ValueError('{} is not callable'.format(
+            func))
+
+    if hasattr(func, 'name'):
+        name = func.name
+    elif isinstance(func, types.FunctionType):
+        name = func.func_name
+    else:
+        name = func.__class__.__name__
+
+    return '.'.join([prefix, name])
+
+
+def python(interpreter='python'):
+    """
+    Execute a callable as an external Python program.
+
+    One of the use cases is to use a different interpreter than the current one
+    such as pypy.
+
+    Arguments of the decorated callable must be serializable in JSON.
+
+    """
+    def wrap_callable(func):
+        @functools.wraps(func)
+        def execute(*args, **kwargs):
+            command = 'simpleflow.execute'  # name of a module.
+            try:
+                output = subprocess.check_output([
+                    interpreter, '-m', command,  # execute module a script.
+                    get_name(func), format_arguments_json(*args, **kwargs),
+                ],
+                    # Redirect stderr to stdout to get traceback on error.
+                    stderr=subprocess.STDOUT,
+                )
+            except subprocess.CalledProcessError as err:
+                exclines = err.output.rstrip().rsplit('\n', 2)
+                if len(exclines) == 1:
+                    excline = exclines[0]
+                else:
+                    excline = exclines[1]
+                exception = pickle.loads(
+                    base64.b64decode(excline.rstrip()))
+                raise exception
+            return json.loads(output)
+
+        # Not automatically assigned in python < 3.2.
+        execute.__wrapped__ = func
+        return execute
+    return wrap_callable
+
+
+def program(path=None, argument_format=format_arguments):
+    """
+    Decorate a callable to execute it as an external program.
+
+    :param path: of the program to execute. If it is ``None`` the name of the
+                 executable will be the name of the callable.
+    :type  path: str.
+    :param argument_format: takes the arguments of the callable and converts
+                            them to command line arguments.
+    :type  argument_format: callable(*args, **kwargs).
+
+    :returns:
+        :rtype: callable(*args, **kwargs).
+
+    Examples
+    --------
+
+    >>> @program()
+    ... def ls(path):
+    ...     pass
+    >>> ls('/etc/resolv.conf')
+    '/etc/resolv.conf\n'
+
+    It will execute the ``ls`` command and requires a single positional
+    argument *path*.
+
+    """
+    import inspect
+
+    def wrap_callable(func):
+        @functools.wraps(func)
+        def execute(*args, **kwargs):
+            check_arguments(argspec, args)
+            check_keyword_arguments(argspec, kwargs)
+
+            command = path or func.func_name
+            return subprocess.check_output(
+                [command] + argument_format(*args, **kwargs))
+
+        argspec = inspect.getargspec(func)
+        # Not automatically assigned in python < 3.2.
+        execute.__wrapped__ = func
+        return execute
+    return wrap_callable
+
+
+def make_callable(funcname):
+    """
+    Return a callable object from a string.
+
+    This function resolves a name into a callable object. It automatically
+    loads the required modules. If there is no module path, it considers the
+    callable is a builtin.
+
+    :param funcname: name of the callable.
+    :type  funcname: str.
+
+    :returns:
+        :rtype: callable.
+
+    Examples
+    --------
+
+    Loading a function from a library:
+
+    >>> func = make_callable('itertools.imap')
+    >>> func
+    itertools.imap
+    >>> list(func(lambda x: x + 1, range(4)))
+    [1, 2, 3, 4]
+
+    Loading a builtin:
+
+    >>> func = make_callable('map')
+    >>> func
+    <function map>
+    >>> func(lambda x: x + 1, range(4))
+    [1, 2, 3, 4]
+
+    """
+    if '.' not in funcname:
+        module_name = '__builtin__'
+        object_name = funcname
+    else:
+        module_name, object_name = funcname.rsplit('.', 1)
+
+    module = __import__(module_name, fromlist=['*'])
+    try:
+        callable_ = getattr(module, object_name)
+    except AttributeError:
+        raise AttributeError('module {} has no attribute {}'.format(
+            module.__name__,
+            object_name,
+        ))
+    return callable_
+
+
+if __name__ == '__main__':
+    """
+    When executed as a script, this module expects the name of a callable as
+    its first argument and the arguments of the callable encoded in a JSON
+    string as its second argument. It then executes the callable with the
+    arguments after decoding them into Python objects. It finally encodes the
+    value returned by the callable into a JSON string and prints it on stdout.
+
+    the arguments of the callable are stored in a dict with the following
+    format: ::
+
+        {'args': [...],
+         'kwargs': {
+            ...,
+         }
+         }
+
+    Synopsis
+    --------
+
+    ::
+        usage: execute.py [-h] funcname funcargs
+
+        positional arguments:
+          funcname    name of the callable to execute
+          funcargs    callable arguments in JSON
+
+        optional arguments:
+          -h, --help  show this help message and exit
+
+    Examples
+    --------
+
+    ::
+        $ python -m simpleflow.execute "os.path.exists" '{"args": ["/tmp"]}'
+        true
+
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'funcname',
+        help='name of the callable to execute',
+    )
+    parser.add_argument(
+        'funcargs',
+        help='callable arguments in JSON',
+    )
+
+    cmd_arguments = parser.parse_args()
+
+    funcname = cmd_arguments.funcname
+    try:
+        arguments = json.loads(cmd_arguments.funcargs)
+    except:
+        raise ValueError('cannot load arguments from {}'.format(
+            cmd_arguments.funcargs))
+
+    callable_ = make_callable(funcname)
+    if hasattr(callable_, '__wrapped__'):
+        callable_ = callable_.__wrapped__
+
+    args = arguments.get('args', ())
+    kwargs = arguments.get('kwargs', {})
+    try:
+        result = callable_(*args, **kwargs)
+    except Exception as err:
+        # Use base64 encoding to avoid carriage returns and special characters.
+        print(base64.b64encode(
+            pickle.dumps(err)))
+        sys.exit(1)
+    else:
+        print(json.dumps(result))

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,97 @@
+import tempfile
+import os.path
+
+import pytest
+
+from simpleflow import activity
+
+
+@activity.execute_program(path='ls')
+def ls_nokwargs(*args):
+    """
+    Only accepts a variable number of positional arguments.
+
+    """
+    pass
+
+
+def test_execute_program_no_kwargs():
+    with tempfile.NamedTemporaryFile() as f:
+        with pytest.raises(TypeError) as exc_info:
+            ls_nokwargs(hide=f.name)
+
+        assert (exc_info.value.message ==
+                'command does not take keyword arguments')
+
+
+@activity.execute_program(path='ls')
+def ls_noargs(**kwargs):
+    """
+    Only accepts a variable number of keyword arguments.
+
+    """
+    pass
+
+
+def test_execute_program_no_args():
+    with tempfile.NamedTemporaryFile() as f:
+        with pytest.raises(TypeError) as exc_info:
+            ls_noargs(f.name)
+
+        assert (exc_info.value.message ==
+                'command does not take varargs')
+
+
+@activity.execute_program(path='ls')
+def ls_restrict_named_arguments(hide=activity.RequiredArgument, *args):
+    pass
+
+
+def test_execute_program_restrict_named_arguments():
+    with tempfile.NamedTemporaryFile() as f:
+        with pytest.raises(TypeError) as exc_info:
+            ls_restrict_named_arguments(f.name)
+
+        assert (exc_info.value.message ==
+                'argument "hide" not found')
+
+
+@activity.execute_program(path='ls')
+def ls_optional_named_arguments(hide='', *args):
+    pass
+
+
+def test_execute_program_optional_named_arguments():
+    with tempfile.NamedTemporaryFile() as f:
+        assert ls_optional_named_arguments(f.name).strip() == f.name
+        assert f.name not in ls_optional_named_arguments(hide=f.name)
+
+
+@activity.execute_program()
+def ls(*args, **kwargs):
+    pass
+
+
+def test_execute_program_with_positional_arguments():
+    with tempfile.NamedTemporaryFile() as f:
+        assert ls(f.name).strip() == f.name
+
+
+def test_execute_program_with_named_arguments():
+    with tempfile.NamedTemporaryFile() as f:
+        assert f.name not in (ls(
+            os.path.dirname(f.name),
+            hide=f.name).strip())
+
+
+@activity.execute_program()
+def ls_2args(a, b):
+    pass
+
+
+def test_ls_2args():
+    with pytest.raises(TypeError) as exc_info:
+        ls_2args(1, 2, 3)
+
+    assert (exc_info.value.message ==
+            'command takes 2 arguments: 3 passed')

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -4,9 +4,10 @@ import os.path
 import pytest
 
 from simpleflow import activity
+from simpleflow import execute
 
 
-@activity.execute_program(path='ls')
+@execute.program(path='ls')
 def ls_nokwargs(*args):
     """
     Only accepts a variable number of positional arguments.
@@ -24,7 +25,7 @@ def test_execute_program_no_kwargs():
                 'command does not take keyword arguments')
 
 
-@activity.execute_program(path='ls')
+@execute.program(path='ls')
 def ls_noargs(**kwargs):
     """
     Only accepts a variable number of keyword arguments.
@@ -42,8 +43,8 @@ def test_execute_program_no_args():
                 'command does not take varargs')
 
 
-@activity.execute_program(path='ls')
-def ls_restrict_named_arguments(hide=activity.RequiredArgument, *args):
+@execute.program(path='ls')
+def ls_restrict_named_arguments(hide=execute.RequiredArgument, *args):
     pass
 
 
@@ -56,7 +57,7 @@ def test_execute_program_restrict_named_arguments():
                 'argument "hide" not found')
 
 
-@activity.execute_program(path='ls')
+@execute.program(path='ls')
 def ls_optional_named_arguments(hide='', *args):
     pass
 
@@ -67,7 +68,7 @@ def test_execute_program_optional_named_arguments():
         assert f.name not in ls_optional_named_arguments(hide=f.name)
 
 
-@activity.execute_program()
+@execute.program()
 def ls(*args, **kwargs):
     pass
 
@@ -84,7 +85,7 @@ def test_execute_program_with_named_arguments():
             hide=f.name).strip())
 
 
-@activity.execute_program()
+@execute.program()
 def ls_2args(a, b):
     pass
 
@@ -95,3 +96,65 @@ def test_ls_2args():
 
     assert (exc_info.value.message ==
             'command takes 2 arguments: 3 passed')
+
+
+@execute.python()
+def inc(xs):
+    return [x + 1 for x in xs]
+
+
+def test_function_as_program():
+    assert inc([1, 2, 3]) == [2, 3, 4]
+
+
+@execute.python()
+def add(a, b=1):
+    return a + b
+
+
+def test_function_as_program_with_default_kwarg():
+    assert add(4) == 5
+
+
+def test_function_as_program_with_kwargs():
+    assert add(3, 7) == 10
+
+
+def test_function_as_program_raises_builtin_exception():
+    with pytest.raises(TypeError):
+        add('1')
+
+
+class DummyException(Exception):
+    pass
+
+
+@execute.python()
+def raise_dummy_exception():
+    raise DummyException
+
+
+def test_function_as_program_raises_custom_exception():
+    with pytest.raises(DummyException):
+        raise_dummy_exception()
+
+
+@execute.python()
+def raise_timeout_error():
+    from simpleflow.exceptions import TimeoutError
+    raise TimeoutError('timeout', 1)
+
+
+def test_function_as_program_raises_module_exception():
+    from simpleflow.exceptions import TimeoutError
+
+    err = None
+    try:
+        raise_timeout_error()
+    except TimeoutError as err:
+        assert err.timeout_type == 'timeout'
+        assert err.timeout_value == 1
+    else:
+        assert False
+
+    assert isinstance(err, TimeoutError)


### PR DESCRIPTION
Please review. Fix #20.

These changes adds the ability to define an activity that executes an external program and a helper to execute a function with another Python interpreter in a sub-process.