### PR TITLE
Feature/workflow stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ And then define the workflow itself in a ``example.py`` file:
 
 Now check that the workflow works locally: ::
 
-    $ simpleflow --local -w example.SimpleComputation -i example/input.json
+    $ simpleflow start --local -i example/input.json example.SimpleComputation
 
 The file ``example/input.json`` contains the input passed to the workflow. It
 should have the format:

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,24 @@ which is equivalent to:
 
     {"kwargs": {"x": 1}}
 
+You can profile the execution of the workflow with:
+
+    $ simpleflow profile DOMAIN WORKFLOW_ID RUN_ID --nb-tasks 3
+
+    Workflow Execution WORKFLOW_ID
+    Domain: DOMAIN
+    Workflow Type: WORKFLOW_TYPE
+
+    Total time = 100.599 seconds
+
+    Start to close timings
+    ----------------------
+    | Task  | Last State   | Scheduled        |    ->  | Start            |    ->  | End              |        % |
+    |:------|:-------------|:-----------------|-------:|:-----------------|-------:|:-----------------|---------:|
+    | task2 | completed    | 2015-06-23 22:27 |  0.09  | 2015-06-23 22:27 | 43.776 | 2015-06-23 22:28 | 43.5153  |
+    | task1 | completed    | 2015-06-23 22:27 |  0.118 | 2015-06-23 22:27 | 28.246 | 2015-06-23 22:27 | 28.0778  |
+    | task3 | completed    | 2015-06-23 22:26 |  0.068 | 2015-06-23 22:26 | 11.159 | 2015-06-23 22:26 | 11.0926  |
+
 Documentation
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,32 @@ which is equivalent to:
 
     {"kwargs": {"x": 1}}
 
-You can profile the execution of the workflow with:
+Then you can run the workflow on Amazon SWF by omitting the ``--local`` flag: ::
 
-    $ simpleflow profile DOMAIN WORKFLOW_ID RUN_ID --nb-tasks 3
+    $ simpleflow start --local -i example/input.json example.SimpleComputation
+
+.. note:: It requires at least a *decider* and a *worker* processes which are not currently provided by the simpleflow package.
+
+You can check the status of the workflow execution with: ::
+
+    $ simpleflow status DOMAIN WORKFLOW_ID [RUN_ID] --nb-tasks 3
+    Workflow Execution WORKFLOW_ID
+    Domain: DOMAIN
+    Workflow Type: WORKFLOW_TYPE
+
+    Total time = 100.599 seconds
+
+    ## Tasks Status
+
+    | Tasks | Last State   | at                         | Scheduled at               |
+    |:------|:-------------|:---------------------------|:---------------------------|
+    | Task3 | completed    | 2015-06-24 12:06:03.397000 |                            |
+    | Task2 | completed    | 2015-06-24 12:05:24.103000 | 2015-06-24 12:05:23.459000 |
+    | Task1 | completed    | 2015-06-24 12:05:23.337000 | 2015-06-24 12:05:22.312000 |
+
+You can profile the execution of the workflow with: ::
+
+    $ simpleflow profile DOMAIN WORKFLOW_ID [RUN_ID] --nb-tasks 3
 
     Workflow Execution WORKFLOW_ID
     Domain: DOMAIN
@@ -98,8 +121,8 @@ You can profile the execution of the workflow with:
 
     Total time = 100.599 seconds
 
-    Start to close timings
-    ----------------------
+    ## Start to close timings
+
     | Task  | Last State   | Scheduled        |    ->  | Start            |    ->  | End              |        % |
     |:------|:-------------|:-----------------|-------:|:-----------------|-------:|:-----------------|---------:|
     | task2 | completed    | 2015-06-23 22:27 |  0.09  | 2015-06-23 22:27 | 43.776 | 2015-06-23 22:28 | 43.5153  |

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,8 @@ Features
 Quickstart
 ----------
 
-Let's take a simple example that computes the result of ``(x + 1) * 2``.
+Let's take a simple example that computes the result of ``(x + 1) * 2``. You
+will find this example in ``examples/basic.py``.
 
 We need to declare the functions as activities to make them available:
 
@@ -61,20 +62,22 @@ And then define the workflow itself in a ``example.py`` file:
 
 .. code::
 
-    from simpleflow import Workflow
-
-    class SimpleComputation(Workflow):
+    class BasicWorkflow(Workflow):
         def run(self, x):
             y = self.submit(increment, x)
             z = self.submit(double, y)
+
+            print '({x} + 1) * 2 = {result}'.format(
+                x=x,
+                result=z.result)
             return z.result
 
 Now check that the workflow works locally: ::
 
-    $ simpleflow start --local -i example/input.json example.SimpleComputation
+    $ simpleflow start --local examples.basic.BasicWorkflow <<< '{"args": [1]}'
+    (1 + 1) * 2 = 4
 
-The file ``example/input.json`` contains the input passed to the workflow. It
-should have the format:
+The *input* can contain ``args`` or ``kwargs`` such as in:
 
 .. code::
 
@@ -88,11 +91,15 @@ which is equivalent to:
 
     {"kwargs": {"x": 1}}
 
-Then you can run the workflow on Amazon SWF by omitting the ``--local`` flag: ::
+You can, of course, pass values in both ``args`` and ``kwargs``.
 
-    $ simpleflow start --local -i example/input.json example.SimpleComputation
+Now that you are confident that the workflow should work, you can run it on
+Amazon SWF by omitting the ``--local`` flag: ::
 
-.. note:: It requires at least a *decider* and a *worker* processes which are not currently provided by the simpleflow package.
+   $ simpleflow --domain test start examples.basic.BasicWorkflow <<< '{"args": [1]}'
+
+.. note:: It requires at least a *decider* and a *worker* processes which are
+   not currently provided by the simpleflow package.
 
 You can check the status of the workflow execution with: ::
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'simple-workflow>=0.1.47',
+        'tabulate==0.7.3',
     ],
     license=read("LICENSE"),
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     install_requires=[
         'simple-workflow>=0.1.47',
         'tabulate==0.7.3',
+        'click',
     ],
     license=read("LICENSE"),
     zip_safe=False,
@@ -103,7 +104,7 @@ setup(
     cmdclass={'test': PyTest},
     entry_points={
         'console_scripts': [
-            'simpleflow = simpleflow.command:main',
+            'simpleflow = simpleflow.command:cli',
         ]
     }
 )

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -45,7 +45,7 @@ def start(local, workflow, input):
 
 @click.option('--nb-tasks', '-n', default=None, type=click.INT,
               help='Maximum number of tasks to display')
-@click.argument('run_id')
+@click.argument('run_id', required=False)
 @click.argument('workflow_id')
 @click.argument('domain')
 @cli.command('profile', help='the tasks of a workflow')
@@ -62,7 +62,7 @@ def profile(domain, workflow_id, run_id, nb_tasks):
 
 @click.option('--nb-tasks', '-n', default=None, type=click.INT,
               help='Maximum number of tasks to display')
-@click.argument('run_id')
+@click.argument('run_id', required=False)
 @click.argument('workflow_id')
 @click.argument('domain')
 @cli.command('status', help='show the status of a workflow execution')

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 import sys
 import json
@@ -6,7 +7,7 @@ import json
 import click
 
 
-__all__ = ['start']
+__all__ = ['start', 'profile']
 
 
 def get_workflow(clspath):
@@ -40,3 +41,15 @@ def start(local, workflow, input):
         from .local import Executor
 
         Executor(workflow_definition).run(input)
+
+
+@click.option('--nb-tasks', '-n', default=None, type=click.INT,
+              help='Maximum number of tasks to display')
+@click.argument('run_id')
+@click.argument('workflow_id')
+@click.argument('domain')
+@cli.command('profile', help='the tasks of a workflow')
+def profile(domain, workflow_id, run_id, nb_tasks):
+    from simpleflow.swf import stats
+
+    print(stats.helpers.show_workflow_stats(domain, workflow_id, run_id, nb_tasks))

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -52,4 +52,26 @@ def start(local, workflow, input):
 def profile(domain, workflow_id, run_id, nb_tasks):
     from simpleflow.swf import stats
 
-    print(stats.helpers.show_workflow_stats(domain, workflow_id, run_id, nb_tasks))
+    print(stats.helpers.show_workflow_stats(
+        domain,
+        workflow_id,
+        run_id,
+        nb_tasks,
+    ))
+
+
+@click.option('--nb-tasks', '-n', default=None, type=click.INT,
+              help='Maximum number of tasks to display')
+@click.argument('run_id')
+@click.argument('workflow_id')
+@click.argument('domain')
+@cli.command('status', help='show the status of a workflow execution')
+def status(domain, workflow_id, run_id, nb_tasks):
+    from simpleflow.swf import stats
+
+    print(stats.helpers.show_workflow_status(
+        domain,
+        workflow_id,
+        run_id,
+        nb_tasks,
+    ))

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import json
 import logging
+import traceback
 
 import swf.format
 import swf.models
@@ -332,15 +333,22 @@ class Executor(executor.Executor):
             return [decision], {}
 
         except Exception, err:
-            reason = 'Cannot replay the workflow {}({})'.format(
+            reason = 'Cannot replay the workflow: {}({})'.format(
                 err.__class__.__name__,
-                err)
-            logger.exception(reason)
+                err,
+            )
+
+            tb = traceback.format_exc()
+            details = 'Traceback:\n{}'.format(tb)
+            logger.exception(reason + '\n' + details)
 
             self.on_failure(reason)
 
             decision = swf.models.decision.WorkflowExecutionDecision()
-            decision.fail(reason=swf.format.reason(reason))
+            decision.fail(
+                reason=swf.format.reason(reason),
+                details=swf.format.details(details),
+            )
 
             return [decision], {}
 

--- a/simpleflow/swf/stats/__init__.py
+++ b/simpleflow/swf/stats/__init__.py
@@ -1,0 +1,3 @@
+from base import *
+import pretty
+import helpers

--- a/simpleflow/swf/stats/base.py
+++ b/simpleflow/swf/stats/base.py
@@ -1,0 +1,84 @@
+from itertools import chain
+
+
+def get_start_to_close_timing(event):
+    last_state = event['state']
+    scheduled = event.get('scheduled_timestamp')
+    if scheduled is None:
+        start = None
+        end = None
+        duration = None
+    else:
+        start = event['started_timestamp']
+        end = event['{}_timestamp'.format(last_state)]
+        duration = (end - start).total_seconds()
+
+    return (last_state, scheduled, start, end, duration)
+
+
+class WorkflowStats(object):
+    def __init__(self, history):
+        self._history = history
+
+    def total_time(self):
+        """
+        Returns the total time of the workflow execution in seconds.
+
+        :returns:
+            :rtype: ``float``.
+
+        """
+        history = self._history
+        start = history.events[0].timestamp
+        end = history.events[-1].timestamp
+        return (end - start).total_seconds()
+
+    def get_timings(self):
+        """
+        Returns the time in seconds spent in the execution of a task, i.e.
+        between the start and the close events, by task ID.
+
+        :returns:
+            :rtype: ``[(str, str, datetime.datetime, datetime.datetime, datetime.datetime, float)]``.
+
+        Example: ::
+
+            [(activity-module.func-1', 'completed', scheduled, start, end, 37.22),
+             ('activity-module.otherfunc-1', 'completed', scheduled, start, end, 13.37)]
+
+        """
+        history = self._history
+        history.parse()
+
+        events = chain(
+            history._activities.iteritems(),
+            history._child_workflows.iteritems(),
+        )
+        return [
+            (name,) + get_start_to_close_timing(attributes) for
+            name, attributes in events
+        ]
+
+    def get_timings_with_percentage(self):
+        """
+        Returns the time in seconds and its percentage against the total time
+        spent in the execution of a task, i.e. between the start and the close
+        events, by task ID.
+
+        :returns:
+            :rtype: ``[(str, str, datetime.datetime, datetime.datetime, datetime.datetime, float, float)]``.
+
+        Example: ::
+
+            [(activity-module.func-1', 'completed', scheduled, start, end, 37.22, 12.4),
+             ('activity-module.otherfunc-1', 'completed', scheduled, start, end, 13.37, 3.8)]
+
+        """
+        TIMING = -1
+        total_time = self.total_time()
+
+        return [
+            (vals + ((vals[TIMING] / total_time) * 100.,) if
+             vals[TIMING] else None) for
+            vals in self.get_timings()
+        ]

--- a/simpleflow/swf/stats/helpers.py
+++ b/simpleflow/swf/stats/helpers.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import swf.models
+import swf.querysets
+
+from . import pretty
+
+
+def show_workflow_stats(domain_name, workflow_id, run_id):
+    domain = swf.models.Domain(domain_name)
+    workflow_execution = (
+        swf.querysets.WorkflowExecutionQuerySet(domain).get(
+            workflow_id=workflow_id,
+            run_id=run_id,
+        )
+    )
+
+    return pretty.show(workflow_execution)

--- a/simpleflow/swf/stats/helpers.py
+++ b/simpleflow/swf/stats/helpers.py
@@ -7,18 +7,39 @@ import swf.exceptions
 from . import pretty
 
 
-def show_workflow_stats(domain_name, workflow_id, run_id, nb_tasks):
+__all__ = ['show_workflow_stats', 'show_workflow_status']
+
+
+def get_workflow_execution(domain_name, workflow_id, run_id):
     domain = swf.models.Domain(domain_name)
+    query = swf.querysets.WorkflowExecutionQuerySet(domain)
     try:
-        workflow_execution = swf.querysets.WorkflowExecutionQuerySet(domain).get(
+        workflow_execution = query.get(
             workflow_id=workflow_id,
             run_id=run_id,
         )
     except swf.exceptions.DoesNotExistError:
-        workflow_execution = swf.querysets.WorkflowExecutionQuerySet(domain).get(
+        workflow_execution = query.get(
             workflow_id=workflow_id,
             run_id=run_id,
             workflow_status=swf.models.WorkflowExecution.STATUS_CLOSED,
         )
+    return workflow_execution
 
+
+def show_workflow_stats(domain_name, workflow_id, run_id, nb_tasks):
+    workflow_execution = get_workflow_execution(
+        domain_name,
+        workflow_id,
+        run_id,
+    )
     return pretty.show(workflow_execution, nb_tasks)
+
+
+def show_workflow_status(domain_name, workflow_id, run_id, nb_tasks):
+    workflow_execution = get_workflow_execution(
+        domain_name,
+        workflow_id,
+        run_id,
+    )
+    return pretty.status(workflow_execution, nb_tasks)

--- a/simpleflow/swf/stats/helpers.py
+++ b/simpleflow/swf/stats/helpers.py
@@ -10,24 +10,34 @@ from . import pretty
 __all__ = ['show_workflow_stats', 'show_workflow_status']
 
 
-def get_workflow_execution(domain_name, workflow_id, run_id):
+def get_workflow_execution(domain_name, workflow_id, run_id=None):
+    def filter_execution(*args, **kwargs):
+        if 'workflow_status' in kwargs:
+            kwargs['status'] = kwargs.pop('workflow_status')
+        return query.filter(*args, **kwargs)[0]
+
     domain = swf.models.Domain(domain_name)
     query = swf.querysets.WorkflowExecutionQuerySet(domain)
+
+    action = filter_execution
+    keywords = {
+        'domain': domain,
+        'workflow_id': workflow_id,
+    }
+    if run_id:
+        action = query.get
+        keywords['run_id'] = run_id
+
     try:
-        workflow_execution = query.get(
-            workflow_id=workflow_id,
-            run_id=run_id,
-        )
-    except swf.exceptions.DoesNotExistError:
-        workflow_execution = query.get(
-            workflow_id=workflow_id,
-            run_id=run_id,
-            workflow_status=swf.models.WorkflowExecution.STATUS_CLOSED,
-        )
+        workflow_execution = action(**keywords)
+    except (swf.exceptions.DoesNotExistError, IndexError):
+        keywords['workflow_status'] = swf.models.WorkflowExecution.STATUS_CLOSED
+        workflow_execution = action(**keywords)
+
     return workflow_execution
 
 
-def show_workflow_stats(domain_name, workflow_id, run_id, nb_tasks):
+def show_workflow_stats(domain_name, workflow_id, run_id=None, nb_tasks=None):
     workflow_execution = get_workflow_execution(
         domain_name,
         workflow_id,
@@ -36,7 +46,7 @@ def show_workflow_stats(domain_name, workflow_id, run_id, nb_tasks):
     return pretty.show(workflow_execution, nb_tasks)
 
 
-def show_workflow_status(domain_name, workflow_id, run_id, nb_tasks):
+def show_workflow_status(domain_name, workflow_id, run_id=None, nb_tasks=None):
     workflow_execution = get_workflow_execution(
         domain_name,
         workflow_id,

--- a/simpleflow/swf/stats/helpers.py
+++ b/simpleflow/swf/stats/helpers.py
@@ -2,17 +2,23 @@ from __future__ import absolute_import
 
 import swf.models
 import swf.querysets
+import swf.exceptions
 
 from . import pretty
 
 
-def show_workflow_stats(domain_name, workflow_id, run_id):
+def show_workflow_stats(domain_name, workflow_id, run_id, nb_tasks):
     domain = swf.models.Domain(domain_name)
-    workflow_execution = (
-        swf.querysets.WorkflowExecutionQuerySet(domain).get(
+    try:
+        workflow_execution = swf.querysets.WorkflowExecutionQuerySet(domain).get(
             workflow_id=workflow_id,
             run_id=run_id,
         )
-    )
+    except swf.exceptions.DoesNotExistError:
+        workflow_execution = swf.querysets.WorkflowExecutionQuerySet(domain).get(
+            workflow_id=workflow_id,
+            run_id=run_id,
+            workflow_status=swf.models.WorkflowExecution.STATUS_CLOSED,
+        )
 
-    return pretty.show(workflow_execution)
+    return pretty.show(workflow_execution, nb_tasks)

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -1,0 +1,89 @@
+import operator
+from datetime import datetime
+
+from tabulate import tabulate
+
+from . import WorkflowStats
+from simpleflow.history import History
+
+
+TEMPLATE = '''
+Workflow Execution {workflow_id}
+Domain: {workflow_type.domain.name}
+Workflow Type: {workflow_type.name}
+
+{tag_list}
+
+Total time = {total_time} seconds
+
+Start to close timings
+----------------------
+{start_to_close_timings}
+
+'''
+
+
+TIME_FORMAT = '%Y-%m-%d %H:%M'
+
+
+def _show_tag_list(tag_list):
+    return '\n'.join(
+        '{}:\t{}'.format(key.strip(), value.strip()) for key, value in (
+            keyval.split('=') for keyval in tag_list
+        )
+    )
+
+
+def _to_timestamp(date):
+    return (date - datetime(1970, 1, 1)).total_seconds()
+
+
+def show(workflow_execution):
+    stats = WorkflowStats(History(workflow_execution.history()))
+
+    start_to_close_values = (
+        (task,
+         last_state,
+         scheduled.strftime(TIME_FORMAT) if scheduled else None,
+         (start - scheduled).total_seconds() if scheduled else None,
+         start.strftime(TIME_FORMAT) if start else None,
+         (end - start).total_seconds() if start else None,
+         end.strftime(TIME_FORMAT) if end else None,
+         percent) for task, last_state, scheduled, start, end, timing, percent in
+        stats.get_timings_with_percentage()
+    )
+    start_to_close_contents = tabulate(
+        sorted(
+            start_to_close_values,
+            key=operator.itemgetter(5),
+            reverse=True,
+        ),
+        headers=(
+            'Task',
+            'Last State',
+            'Scheduled',
+            ' -> ',
+            'Start',
+            ' -> ',
+            'End',
+            '%',
+        ),
+        tablefmt='pipe',  # Markdown-compatible.
+    )
+
+    contents = TEMPLATE.format(
+        workflow_id=workflow_execution.workflow_id,
+        workflow_type=workflow_execution.workflow_type,
+        tag_list=_show_tag_list(workflow_execution.tag_list),
+        total_time=stats.total_time(),
+        start_to_close_timings=start_to_close_contents,
+    )
+
+    return contents
+
+
+def chart(workflow_execution):
+    """
+    Charts like Developer Tools one http://stackoverflow.com/a/21323364
+    """
+    pass

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -50,7 +50,7 @@ def show(workflow_execution, nb_tasks=None):
          (end - start).total_seconds() if start else None,
          end.strftime(TIME_FORMAT) if end else None,
          percent) for task, last_state, scheduled, start, end, timing, percent in
-        stats.get_timings_with_percentage()
+        (row for row in stats.get_timings_with_percentage() if row is not None)
     )
     start_to_close_values = sorted(
         start_to_close_values,

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -73,6 +73,7 @@ def show(workflow_execution, nb_tasks=None):
             '%',
         ),
         tablefmt='pipe',  # Markdown-compatible.
+        floatfmt='.2f',
     )
 
     contents = TEMPLATE.format(

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -38,7 +38,7 @@ def _to_timestamp(date):
     return (date - datetime(1970, 1, 1)).total_seconds()
 
 
-def show(workflow_execution):
+def show(workflow_execution, nb_tasks=None):
     stats = WorkflowStats(History(workflow_execution.history()))
 
     start_to_close_values = (
@@ -52,12 +52,16 @@ def show(workflow_execution):
          percent) for task, last_state, scheduled, start, end, timing, percent in
         stats.get_timings_with_percentage()
     )
+    start_to_close_values = sorted(
+        start_to_close_values,
+        key=operator.itemgetter(5),
+        reverse=True,
+    )
+    if nb_tasks:
+        start_to_close_values = start_to_close_values[:nb_tasks]
+
     start_to_close_contents = tabulate(
-        sorted(
-            start_to_close_values,
-            key=operator.itemgetter(5),
-            reverse=True,
-        ),
+        start_to_close_values,
         headers=(
             'Task',
             'Last State',

--- a/tests/swf/test_stats.py
+++ b/tests/swf/test_stats.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+from swf.models.history import builder
+
+from simpleflow import (
+    Workflow,
+    activity,
+)
+from simpleflow.history import History
+from simpleflow.swf.stats import WorkflowStats
+
+
+@activity.with_attributes(version='test')
+def increment(x):
+    return x + 1
+
+
+class TestWorkflow(Workflow):
+    name = 'test_workflow'
+    version = 'test_version'
+    task_list = 'test_task_list'
+    decision_tasks_timeout = '300'
+    execution_timeout = '3600'
+    tag_list = None      # FIXME should be optional
+    child_policy = None  # FIXME should be optional
+
+    def run(self, **context):
+        return 0
+
+
+def test_last_state_times():
+    """
+    This test checks an execution with a single activity tasks.
+
+    """
+    history_builder = builder.History(TestWorkflow)
+
+    last_state = 'completed'
+    activity_id = 'activity-tests.test_dataflow.increment-1'
+
+    history_builder.add_activity_task(
+        increment,
+        decision_id=0,
+        last_state=last_state,
+        activity_id=activity_id,
+    )
+
+    history = History(history_builder)
+    stats = WorkflowStats(history)
+    total_time = stats.total_time()
+
+    events = history.events
+    assert total_time == (
+        events[-1].timestamp - events[0].timestamp
+    ).total_seconds()
+    timings = stats.get_timings()[0]
+    assert timings[0] == activity_id
+    assert timings[1] == last_state
+
+    TIMING_SCHEDULED = 2
+    TIMING_STARTED = 3
+    TIMING_COMPLETED = 4
+
+    EV_SCHEDULED = -3
+    EV_STARTED = -2
+    EV_COMPLETED = -1
+
+    assert timings[TIMING_SCHEDULED] == events[EV_SCHEDULED].timestamp
+    assert timings[TIMING_STARTED] == events[EV_STARTED].timestamp
+    assert timings[TIMING_COMPLETED] == events[EV_COMPLETED].timestamp
+
+    TIMING_DURATION = 5
+    assert timings[TIMING_DURATION] == (
+        events[EV_COMPLETED].timestamp - events[EV_STARTED].timestamp
+    ).total_seconds()
+
+    timings = stats.get_timings_with_percentage()[0]
+    TIMING_TOTAL_TIME = -2
+    TIMING_PERCENTAGE = -1
+    percentage = (timings[TIMING_TOTAL_TIME] / total_time) * 100.
+    assert percentage == timings[TIMING_PERCENTAGE]


### PR DESCRIPTION
#24

Adds a set of helpers and commands to generate statistics from the history of a workflow.

`swf.stats.WorkflowStats` takes a `history` and returns timings with `.get_timings()` and `.get_timings_with_percentage()` (could use a flag).

To quickly display a tabular representation of the profiling of an execution use  `swf.stats.helpers.show_workflow_stats()`. If you want to check the status of the tasks in the execution use `swf.stats.helpers.show_workflow_status()`.

You can directly use the commands:

```sh
$ simpleflow profile --help
Usage: simpleflow profile [OPTIONS] DOMAIN WORKFLOW_ID [RUN_ID]

  the tasks of a workflow

Options:
  -n, --nb-tasks INTEGER  Maximum number of tasks to display
  --help                  Show this message and exit.

$ simpleflow status --help
Usage: simpleflow status [OPTIONS] DOMAIN WORKFLOW_ID [RUN_ID]

  show the status of a workflow execution

Options:
  -n, --nb-tasks INTEGER  Maximum number of tasks to display
  --help                  Show this message and exit.
```