### PR TITLE
Fix/swf messages too long

### DIFF
--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import json
 import logging
 
+import swf.format
 import swf.models
 import swf.models.decision
 import swf.exceptions
@@ -306,8 +307,9 @@ class Executor(executor.Executor):
 
             decision = swf.models.decision.WorkflowExecutionDecision()
             decision.fail(
-                reason=reason,
-                details=details)
+                reason=swf.format.reason(reason),
+                details=swf.format.details(details),
+            )
             return [decision], {}
 
         except Exception, err:
@@ -319,7 +321,7 @@ class Executor(executor.Executor):
             self.on_failure(reason)
 
             decision = swf.models.decision.WorkflowExecutionDecision()
-            decision.fail(reason=reason)
+            decision.fail(reason=swf.format.reason(reason))
 
             return [decision], {}
 
@@ -339,8 +341,10 @@ class Executor(executor.Executor):
 
         decision = swf.models.decision.WorkflowExecutionDecision()
         decision.fail(
-            reason='Workflow execution failed: {}'.format(reason),
-            details=details)
+            reason=swf.format.reason(
+                'Workflow execution failed: {}'.format(reason)),
+            details=swf.format.details(details),
+        )
 
         self._decisions.append(decision)
         raise exceptions.ExecutionBlocked('workflow execution failed')

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -326,7 +326,7 @@ class Executor(executor.Executor):
             return [decision], {}
 
         decision = swf.models.decision.WorkflowExecutionDecision()
-        decision.complete(result=json.dumps(result))
+        decision.complete(result=swf.format.result(json.dumps(result)))
 
         return [decision], {}
 


### PR DESCRIPTION
Wrap values that may be too long for SWF such as:

- *reason*
- *details*
- *result* of the workflow

There is still tasks *input* and *result* to address. They require a careful handling because there are not only *informational* values, they are used for computations. 