### PR TITLE
Add before/after run hooks

### DIFF
--- a/simpleflow/executor.py
+++ b/simpleflow/executor.py
@@ -56,7 +56,13 @@ class Executor(object):
         Runs the workflow definition.
 
         """
-        return self._workflow.run(*args, **kwargs)
+        workflow = self._workflow
+
+        self.before_run()
+        result = workflow.run(*args, **kwargs)
+        self.after_run()
+
+        return result
 
     @abc.abstractmethod
     def submit(self, task, *args, **kwargs):
@@ -86,6 +92,9 @@ class Executor(object):
         return [self.submit(callable, *arguments) for
                 arguments in iterable]
 
+    def before_run(self):
+        pass
+
     @abc.abstractmethod
     def run(self, *args, **kwargs):
         """
@@ -93,6 +102,9 @@ class Executor(object):
 
         """
         raise NotImplementedError()
+
+    def after_run(self):
+        pass
 
     def on_failure(self, reason, details=None):
         """

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -368,5 +368,11 @@ class Executor(executor.Executor):
         self._decisions.append(decision)
         raise exceptions.ExecutionBlocked('workflow execution failed')
 
+    def before_run(self):
+        return self._workflow.before_run(self._history)
+
     def run(self, history):
         return self.replay(history)
+
+    def after_run(self):
+        return self._workflow.after_run(self._history)

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -60,8 +60,14 @@ class Workflow(object):
     def fail(self, reason, details=None):
         self._executor.fail(reason, details)
 
+    def before_run(self, history):
+        pass
+
     def run(self, *args, **kwargs):
         raise NotImplementedError
+
+    def after_run(self, history):
+        pass
 
     def on_failure(self, history, reason, details=None):
         """

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -112,6 +112,59 @@ def test_workflow_with_input():
     assert decisions[0] == workflow_completed
 
 
+class TestDefinitionWithBeforeRun(TestWorkflow):
+    """
+    Execute a single task with an argument passed as the workflow's input.
+
+    """
+    def before_run(self, history):
+        self.a = history.events[0].input['args'][0]
+
+    def run(self, a):
+        b = self.submit(increment, a)
+        return b.result
+
+
+def test_workflow_with_before_run():
+    workflow = TestDefinitionWithBeforeRun
+    executor = Executor(DOMAIN, workflow)
+
+    history = builder.History(workflow,
+                              input={'args': (4,)})
+
+    # The executor should only schedule the *increment* task.
+    assert not hasattr(executor._workflow, 'a')
+    decisions, _ = executor.replay(history)
+    assert executor._workflow.a == 4
+
+
+class TestDefinitionWithAfterRun(TestWorkflow):
+    """
+    Execute a single task with an argument passed as the workflow's input.
+
+    """
+    def before_run(self, history):
+        self.b = history.events[0].input['args'][0] + 1
+
+    def run(self, a):
+        b = self.submit(increment, a)
+        return b.result
+
+
+def test_workflow_with_after_run():
+    workflow = TestDefinitionWithAfterRun
+    executor = Executor(DOMAIN, workflow)
+
+    history = builder.History(workflow,
+                              input={'args': (4,)})
+
+    # The executor should only schedule the *increment* task.
+    assert not hasattr(executor._workflow, 'b')
+    decisions, _ = executor.replay(history)
+    assert executor._workflow.b == 5
+
+
+
 class TestDefinition(TestWorkflow):
     """
     Executes two tasks. The second depends on the first.


### PR DESCRIPTION
Add two hook methods to the `Workflow` class: `.before_run()` and `.after_run()` that respectively execute before and after the `Workflow.run()` method.