### PR TITLE
Add decider and worker processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ Features
 - Handle the completion of a decision with more than 100 tasks.
 - Provides a local executor to check a workflow without Amazon SWF (see
   ``simpleflow --local`` command).
+- Provides decider and activity worker process for execution with Amazon SWF.
+- Ships with the `simpleflow` command. `simpleflow --help` for more information
+  about the commands it supports.
 
 Quickstart
 ----------
@@ -45,101 +48,179 @@ will find this example in ``examples/basic.py``.
 
 We need to declare the functions as activities to make them available:
 
-.. code::
+.. code:: python
 
-    from simpleflow import activity
+    from simpleflow import (
+        activity,
+        Workflow,
+        futures,
+    )
 
-    @activity.with_attributes(task_list='quickstart')
+    @activity.with_attributes(task_list='quickstart', version='example')
     def increment(x):
         return x + 1
 
-    @activity.with_attributes(task_list='quickstart')
+    @activity.with_attributes(task_list='quickstart', version='example')
     def double(x):
         return x * 2
 
+    @activity.with_attributes(task_list='quickstart', version='example')
+    def delay(t, x):
+        time.sleep(t)
+        return x
 
 And then define the workflow itself in a ``example.py`` file:
 
-.. code::
+.. code:: python
 
     class BasicWorkflow(Workflow):
-        def run(self, x):
+        name = 'basic'
+        version = 'example'
+        task_list = 'example'
+
+        def run(self, x, t=30):
             y = self.submit(increment, x)
+            yy = self.submit(delay, t, y)
             z = self.submit(double, y)
 
             print '({x} + 1) * 2 = {result}'.format(
                 x=x,
                 result=z.result)
+            futures.wait(yy, z)
             return z.result
 
 Now check that the workflow works locally: ::
 
-    $ simpleflow start --local examples.basic.BasicWorkflow <<< '{"args": [1]}'
+    $ simpleflow start --local examples.basic.BasicWorkflow --input '[1, 1]'
     (1 + 1) * 2 = 4
 
-The *input* can contain ``args`` or ``kwargs`` such as in:
-
-.. code::
-
-    {"args": [1],
-     "kwargs": {}
-    }
-
-which is equivalent to:
-
-.. code::
-
-    {"kwargs": {"x": 1}}
-
-You can, of course, pass values in both ``args`` and ``kwargs``.
+*input* is encoded in JSON format and can contain the list of *positional*
+arguments such as ``'[1, 1]`` or a *dict* with the ``args`` and ``kwargs`` keys
+such as ``{"args": [1], "kwargs": {}}``, ``{"kwargs": {"x": 1}}``, or
+``'{"args": [1], "kwargs": {"t": 1}}'```.
 
 Now that you are confident that the workflow should work, you can run it on
-Amazon SWF by omitting the ``--local`` flag: ::
+Amazon SWF with the ``standalone`` command : ::
 
-   $ simpleflow --domain test start examples.basic.BasicWorkflow <<< '{"args": [1]}'
+   $ simpleflow standalone --domain TestDomain examples.basic.BasicWorkflow --input '[1, 1]'
 
-.. note:: It requires at least a *decider* and a *worker* processes which are
-   not currently provided by the simpleflow package.
+The *standalone* command sets an unique task list and manage all the processes
+that are needed to execute the workflow: decider, activity worker, and a client
+that starts the workflow. It is very convenient for testing a workflow by
+executing it with SWF during the development steps or integration tests.
+
+Let's take a closer look to the workflow definition.
+
+It is a *class* that inherits from :class:`simpleflow.Workflow`:
+
+    .. code:: python
+
+    class BasicWorkflow(Workflow):
+
+It defines 3 class attributes:
+
+- *name*, the name of the SWF workflow type.
+- *version*, the version of the SWF workflow type. It is currently provided
+  only for labeling a workflow.
+- *task_list*, the default task list (see it as a dynamically created queue)
+  where decision tasks for this workflow will be sent. Any *decider* that
+  listens on this task list can handle this workflow. This value can be
+  overrided by the simpleflow commands and objects.
+
+It also implements the :meth:`run` method that takes two arguments: ``x`` and
+``t=30`` (i.e. ``t`` is optional and has the default value ``30``). These
+arguments are passed with the ``--input`` option. The :meth:`run` method
+describes the workflow and how its tasks should execute.
+
+Each time a decider takes a decision task, it executes again the :meth:`run`
+from the start. When the workflow execution starts, it evaluates ``y =
+self.submit(increment, x)`` for the first time. *y* holds a future in state
+``PENDING``. The execution continues with the line ``yy = self.submit(delay, t,
+y)``. *yy* holds another future in state ``PENDING``. This state means the task
+has not been scheduled. Now execution still continue in the :meth:`run` method
+with the line ``z = self.submit(double, y)``. Here it needs the value of the
+*y* future to evaluate the :func:`double` activity. As the execution cannot
+continues, the decider schedules the task :func:`increment`. *yy* is not a
+dependency for any task so it is not scheduled.
+
+Once the decider has scheduled the task for *y*, it sleeps and waits for an
+event to be waken up. This happens when the :func:`increment` task completes.
+SWF schedules a decision task. A decider takes it and executes the
+:meth:`BasicWorkflow.run` method again from the start. It evalues the line ``y
+= self.submit(increment, x)``. The task associated with the *y* future has
+completed. Hence *y* is in state ``FINISHED`` and contains the value ``2`` in
+``y.result``. The execution continues until it blocks. It goes by ``yy =
+self.submit(delay, t, y)`` that stays the same. Then it reaches ``z =
+self.submit(double, y)``. It gets the value of ``y.result`` and *z* now holds a
+future in state ``PENDING``. Execution reaches the line with the ``print``. It
+blocks here because ``z.result`` is not available. The decider schedules the
+task backs by the *z* future: ``double(y)``. The workflow execution continues
+so forth by evaluating the :meth:`BasicWorkflow.run` again from the start until
+the it finishes.
+
+Commands
+--------
+
+Overview
+~~~~~~~~
+
+Please read and even run the `demo` script to have a quick glances of
+`simpleflow` commands. To run the `demo` you will need to start decider and
+activity worker processes.
+
+Start a decider with: ::
+
+    $ simpleflow decider.start --log-level 1 --domain TestDomain --task-list test examples.basic.BasicWorkflow
+
+Start an activity worker with: ::
+
+    $ simpleflow worker.start --domain TestDomain --task-list quickstart examples.basic.BasicWorkflow
+
+Then execute ``./demo``.
+
+List Workflow Executions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+    $ simpleflow workflow.list TestDomain
+    basic-example-1438722273  basic  OPEN
+
+Workflow Execution Status
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    $ simpleflow --header workflow.info TestDomain basic-example-1438722273
+    domain      workflow_type.name    workflow_type.version      task_list  workflow_id               run_id                                          tag_list      execution_time  input
+    TestDomain  basic                 example                               basic-example-1438722273  22QFVi362TnCh6BdoFgkQFlocunh24zEOemo1L12Yl5Go=                          1.70  {u'args': [1], u'kwargs': {}}
+
+Tasks Status
+~~~~~~~~~~~~
 
 You can check the status of the workflow execution with: ::
 
-    $ simpleflow status DOMAIN WORKFLOW_ID [RUN_ID] --nb-tasks 3
-    Workflow Execution WORKFLOW_ID
-    Domain: DOMAIN
-    Workflow Type: WORKFLOW_TYPE
+    $ simpleflow --header workflow.tasks DOMAIN WORKFLOW_ID [RUN_ID] --nb-tasks 3
+    $ simpleflow --header workflow.tasks TestDomain basic-example-1438722273
+    Tasks                     Last State    Last State Time             Scheduled Time
+    examples.basic.increment  scheduled     2015-08-04 23:04:34.510000  2015-08-04 23:04:34.510000
+    $ simpleflow --header workflow.tasks TestDomain basic-example-1438722273
+    Tasks                     Last State    Last State Time             Scheduled Time
+    examples.basic.double     completed     2015-08-04 23:06:19.200000  2015-08-04 23:06:17.738000
+    examples.basic.delay      completed     2015-08-04 23:08:18.402000  2015-08-04 23:06:17.738000
+    examples.basic.increment  completed     2015-08-04 23:06:17.503000  2015-08-04 23:04:34.510000
 
-    Total time = 100.599 seconds
-
-    ## Tasks Status
-
-    | Tasks | Last State   | at                         | Scheduled at               |
-    |:------|:-------------|:---------------------------|:---------------------------|
-    | Task3 | completed    | 2015-06-24 12:06:03.397000 |                            |
-    | Task2 | completed    | 2015-06-24 12:05:24.103000 | 2015-06-24 12:05:23.459000 |
-    | Task1 | completed    | 2015-06-24 12:05:23.337000 | 2015-06-24 12:05:22.312000 |
+Profiling
+~~~~~~~~~~~~
 
 You can profile the execution of the workflow with: ::
 
-    $ simpleflow profile DOMAIN WORKFLOW_ID [RUN_ID] --nb-tasks 3
-
-    Workflow Execution WORKFLOW_ID
-    Domain: DOMAIN
-    Workflow Type: WORKFLOW_TYPE
-
-    Total time = 100.599 seconds
-
-    ## Start to close timings
-
-    | Task  | Last State   | Scheduled        |    ->  | Start            |    ->  | End              |        % |
-    |:------|:-------------|:-----------------|-------:|:-----------------|-------:|:-----------------|---------:|
-    | task2 | completed    | 2015-06-23 22:27 |  0.09  | 2015-06-23 22:27 | 43.776 | 2015-06-23 22:28 | 43.5153  |
-    | task1 | completed    | 2015-06-23 22:27 |  0.118 | 2015-06-23 22:27 | 28.246 | 2015-06-23 22:27 | 28.0778  |
-    | task3 | completed    | 2015-06-23 22:26 |  0.068 | 2015-06-23 22:26 | 11.159 | 2015-06-23 22:26 | 11.0926  |
+    $ simpleflow --header workflow.profile TestDomain basic-example-1438722273
+    Task                                 Last State    Scheduled           Time Scheduled  Start               Time Running  End                 Percentage of total time
+    activity-examples.basic.double-1     completed     2015-08-04 23:06              0.07  2015-08-04 23:06            1.39  2015-08-04 23:06                        1.15
+    activity-examples.basic.increment-1  completed     2015-08-04 23:04            102.20  2015-08-04 23:06            0.79  2015-08-04 23:06                        0.65
 
 Documentation
 -------------
 
-Full documentation is available at https://simpleflow.readthedocs.org/.
+Full documentation (work-in-progress) is available at
+https://simpleflow.readthedocs.org/.
 
 Requirements
 ------------

--- a/demo
+++ b/demo
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+INTERACTIVE=${INTERACTIVE:=0}
+
+LIGHT_GRAY="\033[0;37m"
+NO_COLOUR="\033[0m"
+
+wait_next() {
+	local text='<Press Enter>'
+
+	if [ $INTERACTIVE -ne 0 ]
+	then
+		tput sc; tput bold; echo -en "$text"
+		read
+		tput rc; tput el
+		echo -en "\n"
+	else
+		sleep 1
+
+	echo -en "\n"
+	fi
+}
+
+type_command() {
+	local cmd="$1"
+	echo -n '$ '
+	sleep 1
+	human_type "$cmd"
+	wait_next
+	$cmd
+	wait_next
+}
+
+human_type() {
+	local length=$( expr ${#1} )
+	i=0
+	while [[ i -le length ]]
+	do
+		echo -en "${1:i:1}"
+		sleep 0.02
+		i=$i+1
+	done
+}
+
+comment() {
+	echo -en ${LIGHT_GRAY}
+	echo -en "$1"
+	echo -en ${NO_COLOUR}
+	sleep 1
+}
+
+typing_comment() {
+	echo -en ${LIGHT_GRAY}
+	human_type "$1"
+	echo -en ${NO_COLOUR}
+	sleep 1
+	echo
+}
+
+start_workflow() {
+	sleep 1
+	comment '# OK. '
+	typing_comment "So, now let's start a workflow."
+	# Have an issue with the --input argument. Let's write boilerplate.
+	echo -n '$ '
+	cmd="simpleflow workflow.start --domain TestDomain --task-list test --input '{\"args\": [1, 120]}' examples.basic.BasicWorkflow"
+	human_type "$cmd"
+	wait_next
+	
+	output=$( simpleflow workflow.start --domain TestDomain --task-list test --input '{"args": [1, 120]}' examples.basic.BasicWorkflow )
+	echo -n $output
+	workflow_id=$( echo $output | cut -d' ' -f1 )
+	echo; echo
+	wait_next
+}
+
+sleep 1
+
+comment '# Euh... '
+typing_comment 'What do I do???'
+comment 'HELP!\n'
+type_command 'simpleflow --help'
+
+start_workflow
+
+typing_comment '# How is it running?'
+type_command "simpleflow workflow.tasks TestDomain ${workflow_id}"
+
+typing_comment '# Oh! So, increment is finished. What did it return?'
+type_command "simpleflow --header task.info TestDomain ${workflow_id} activity-examples.basic.increment-1"
+
+typing_comment '# Are there any other workflow running?'
+type_command 'simpleflow workflow.list TestDomain'
+
+typing_comment '# Is my workflow running well?'
+type_command "simpleflow --header workflow.tasks TestDomain ${workflow_id}"
+
+typing_comment "# Let's profile the execution!"
+type_command "simpleflow --header workflow.profile TestDomain ${workflow_id}"
+
+typing_comment '# What about the workflow?'
+type_command "simpleflow --header workflow.info TestDomain ${workflow_id}"
+
+typing_comment '# I want to parse the profile output as a CSV file'
+typing_comment '# No problem!'
+type_command "simpleflow --format csv workflow.profile TestDomain ${workflow_id}"

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -6,12 +6,12 @@ from simpleflow import (
 )
 
 
-@activity.with_attributes(task_list='quickstart')
+@activity.with_attributes(task_list='quickstart', version='example')
 def increment(x):
     return x + 1
 
 
-@activity.with_attributes(task_list='quickstart')
+@activity.with_attributes(task_list='quickstart', version='example')
 def double(x):
     return x * 2
 
@@ -25,6 +25,7 @@ def delay(t, x):
 class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
+    task_list = 'example'
 
     def run(self, x, t=30):
         y = self.submit(increment, x)

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -3,6 +3,7 @@ import time
 from simpleflow import (
     activity,
     Workflow,
+    futures,
 )
 
 
@@ -35,11 +36,12 @@ class BasicWorkflow(Workflow):
     def run(self, x, t=30):
         y = self.submit(increment, x)
         yy = self.submit(delay, t, y)
-        z = self.submit(double, yy)
+        z = self.submit(double, y)
 
         print '({x} + 1) * 2 = {result}'.format(
             x=x,
             result=z.result)
+        futures.wait(yy, z)
         return z.result
 
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -22,6 +22,11 @@ def delay(t, x):
     return x
 
 
+@activity.with_attributes(task_list='quickstart', version='example')
+def add(x, y):
+    return x + y
+
+
 class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
@@ -36,3 +41,20 @@ class BasicWorkflow(Workflow):
             x=x,
             result=z.result)
         return z.result
+
+
+@activity.with_attributes(task_list='quickstart', version='example')
+def fail(x):
+    return fail
+
+
+class FailingWorkflow(Workflow):
+    name = 'failing'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self, x):
+        y = self.submit(fail, x)
+        z = self.submit(fail, x)
+        output = self.submit(add, y, z)
+        return output.result

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ DEPS = [
     'subprocess32',
     'setproctitle',
     'click',
+    'psutil',
 ]
 if platform.python_implementation().lower() != 'pypy':
     DEPS.append('faulthandler')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import platform
 import re
 import sys
 import subprocess
@@ -68,6 +69,16 @@ def read(fname):
         content = fp.read()
     return content
 
+DEPS = [
+    'simple-workflow>=0.1.49',
+    'tabulate==0.7.3',
+    'subprocess32',
+    'setproctitle',
+    'click',
+]
+if platform.python_implementation().lower() != 'pypy':
+    DEPS.append('faulthandler')
+
 setup(
     name='simpleflow',
     version=__version__,
@@ -80,14 +91,7 @@ setup(
     packages=find_packages(exclude=("test*", )),
     package_dir={'simpleflow': 'simpleflow'},
     include_package_data=True,
-    install_requires=[
-        'simple-workflow>=0.1.49',
-        'tabulate==0.7.3',
-        'subprocess32',
-        'faulthandler',
-        'setproctitle',
-        'click',
-    ],
+    install_requires=DEPS,
     license=read("LICENSE"),
     zip_safe=False,
     keywords='simpleflow',

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ setup(
     install_requires=[
         'simple-workflow>=0.1.49',
         'tabulate==0.7.3',
+        'subprocess32',
+        'faulthandler',
+        'setproctitle',
         'click',
     ],
     license=read("LICENSE"),

--- a/simpleflow/__init__.py
+++ b/simpleflow/__init__.py
@@ -4,5 +4,12 @@ __version__ = '0.6.1'
 __author__ = 'Greg Leclercq'
 __license__ = "MIT"
 
+import logging.config
+
 from .activity import Activity
 from .workflow import Workflow
+
+from . import settings
+
+
+logging.config.dictConfig(settings.base.load()['LOGGING'])

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -61,7 +61,7 @@ class Activity(object):
         self.register()
 
     def register(self):
-        task.registry.register(self, self.task_list)
+        task.registry.register(self)
 
     @property
     def name(self):

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -1,16 +1,21 @@
+from . import settings
 from . import task
 
 
 __all__ = ['with_attributes', 'Activity']
 
 
-def with_attributes(name=None, version=None, task_list=None,
-                    retry=0,
-                    raises_on_failure=False,
-                    start_to_close_timeout=None,
-                    schedule_to_close_timeout=None,
-                    schedule_to_start_timeout=None,
-                    heartbeat_timeout=None):
+def with_attributes(
+        name=None,
+        version=settings.ACTIVITY_DEFAULT_VERSION,
+        task_list=settings.ACTIVITY_DEFAULT_TASK_LIST,
+        retry=0,
+        raises_on_failure=False,
+        start_to_close_timeout=settings.ACTIVITY_START_TO_CLOSE_TIMEOUT,
+        schedule_to_close_timeout=settings.ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
+        schedule_to_start_timeout=settings.ACTIVITY_SCHEDULE_TO_START_TIMEOUT,
+        heartbeat_timeout=settings.ACTIVITY_HEARTBEAT_TIMEOUT,
+):
     """
     :param name: of the activity type.
     :type  name: str.

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -49,6 +49,20 @@ def get_workflow_type(domain_name, workflow):
     return query.get_or_create(workflow.name, workflow.version)
 
 
+def get_input(input=None):
+    if not input:
+        input = json.loads(sys.stdin.read())
+    else:
+        input = json.loads(input)
+
+    if isinstance(input, list):
+        input = {
+            'args': input,
+            'kwargs': {},
+        }
+    return input
+
+
 @click.option('--local', default=False, is_flag=True,
               required=False,
               help='Run the workflow locally without calling Amazon SWF')
@@ -84,11 +98,8 @@ def start_workflow(workflow,
           input,
           local):
     workflow_definition = get_workflow(workflow)
-    if not input:
-        input = json.loads(sys.stdin.read())
-    else:
-        input = json.loads(input)
 
+    input = get_input(input)
     if local:
         from .local import Executor
 

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -11,6 +11,7 @@ import swf.querysets
 
 from simpleflow.swf.stats import pretty
 from simpleflow.swf import helpers
+from simpleflow.swf.process import decider
 
 
 __all__ = ['start', 'info', 'profile', 'status', 'list']
@@ -144,6 +145,7 @@ def with_format(ctx):
         fmt=ctx.parent.params['format'] or pretty.DEFAULT_FORMAT,
     )
 
+
 @click.argument('run_id', required=False)
 @click.argument('workflow_id')
 @click.argument('domain')
@@ -203,3 +205,19 @@ def list_workflows(ctx, domain):
 @click.pass_context
 def task_info(ctx, domain, workflow_id, task_id):
     print(with_format(ctx)(helpers.get_task)(domain, workflow_id, task_id))
+
+
+@click.option('--nb-processes', '-N', type=int)
+@click.option('--log-level', '-l')
+@click.option('--task-list')
+@click.option('--domain', '-d', required=True, help='SWF Domain')
+@click.argument('workflows', nargs=-1, required=True)
+@cli.command('decider.start', help='start a decider process to manage workflow executions')
+def start_decider(workflows, domain, task_list, log_level, nb_processes):
+    decider.command.start(
+        workflows,
+        domain,
+        task_list,
+        log_level,
+        nb_processes,
+    )

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -12,6 +12,7 @@ import swf.querysets
 from simpleflow.swf.stats import pretty
 from simpleflow.swf import helpers
 from simpleflow.swf.process import decider
+from simpleflow.swf.process import worker
 
 
 __all__ = ['start', 'info', 'profile', 'status', 'list']
@@ -219,5 +220,20 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
         domain,
         task_list,
         log_level,
+        nb_processes,
+    )
+
+
+@click.option('--nb-processes', '-N', type=int)
+@click.option('--log-level', '-l')
+@click.option('--task-list')
+@click.option('--domain', '-d', required=True, help='SWF Domain')
+@click.argument('workflow')
+@cli.command('worker.start', help='a worker process to handle activity tasks')
+def start_worker(workflow, domain, task_list, log_level, nb_processes):
+    worker.command.start(
+        workflow,
+        domain,
+        task_list,
         nb_processes,
     )

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -33,16 +33,18 @@ class TaskFailed(Exception):
     :type  details: str.
 
     """
-    def __init__(self, reason, details=None):
-        super(TaskFailed, self).__init__(self, reason, details)
+    def __init__(self, name, reason, details=None):
+        super(TaskFailed, self).__init__(name, reason, details)
+        self.name = name
         self.reason = reason
         self.details = None
 
     def __repr__(self):
-        return '{}(reason="{}")'.format(
+        return '{}({}, "{}")'.format(
             self.__class__.__name__,
+            self.name,
             self.reason,
-            self.details)
+        )
 
 
 class TimeoutError(Exception):
@@ -54,3 +56,19 @@ class TimeoutError(Exception):
         return '{}({})'.format(
             self.__class__.__name__,
             self.timeout_type)
+
+
+class MultipleExceptions(Exception):
+    def __init__(self, msg, exceptions):
+        super(MultipleExceptions, self).__init__(msg, exceptions)
+        self.exceptions = exceptions
+
+    def __repr__(self):
+        return '{}({}, {})'.format(
+            self.__class__.__name__,
+            self.msg,
+            ', '.join(str(exc) for exc in self.exceptions),
+        )
+
+    def __unicode__(self):
+        return self.__repr__()

--- a/simpleflow/futures.py
+++ b/simpleflow/futures.py
@@ -81,6 +81,9 @@ class Future(object):
         if self._state != FINISHED:
             return self.wait()
 
+        if self._exception is not None:
+            raise self._exception
+
         return self._result
 
     def cancel(self):
@@ -126,6 +129,10 @@ class Future(object):
     @property
     def finished(self):
         return self._state == FINISHED
+
+    @property
+    def failed(self):
+        return self._state == FINISHED and self._exception is not None
 
     @property
     def done(self):

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -90,7 +90,7 @@ class History(object):
             activity = get_activity(event)
             activity['state'] = event.state
             activity['reason'] = event.reason
-            activity['details'] = event.details
+            activity['details'] = getattr(event, 'details', '')
             activity['failed_timestamp'] = event.timestamp
             if 'retry' not in activity:
                 activity['retry'] = 0

--- a/simpleflow/settings/__init__.py
+++ b/simpleflow/settings/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+import base
+
+
+for k, v in base.load().iteritems():
+    setattr(sys.modules[__name__], k, v)

--- a/simpleflow/settings/base.py
+++ b/simpleflow/settings/base.py
@@ -1,0 +1,70 @@
+import sys
+
+from . import default
+
+
+class Setting(object):
+    pass
+
+
+def is_definition(var):
+    if var.startswith('_'):
+        return False
+    return all(c.isupper() for c in var if c.isalpha())
+
+
+def get_settings(module):
+    return {
+        var: getattr(module, var) for var in dir(module) if
+        is_definition(var)
+    }
+
+
+def load_settings(module, env, conf, defaults):
+    settings = {}
+    value = None
+    for name, typ in get_settings(module).iteritems():
+        if name in env:
+            value = env[name]
+        elif name in conf:
+            value = conf[name]
+        else:
+            value = getattr(defaults, name)
+
+        settings[name] = typ(value)
+
+    return settings
+
+
+def load(conf_module_name=None):
+    import os
+
+    env = os.environ
+    conf_module_name = conf_module_name or env.get('SIMPLEFLOW_SETTINGS_MODULE')
+    if conf_module_name:
+        conf = __import__(conf_module_name, fromlist=['*'])
+    else:
+        conf = {}
+
+    return load_settings(
+        sys.modules[__name__],
+        env,
+        conf,
+        default,
+    )
+
+
+WORKFLOW_DEFAULT_TASK_LIST = str
+WORKFLOW_DEFAULT_VERSION = str
+WORKFLOW_DEFAULT_EXECUTION_TIME = str
+WORKFLOW_DEFAULT_DECISION_TASK_TIMEOUT = str
+
+ACTIVITY_DEFAULT_TASK_LIST = str
+ACTIVITY_DEFAULT_VERSION = str
+ACTIVITY_DEFAULT_TIMEOUT = str
+ACTIVITY_START_TO_CLOSE_TIMEOUT = str
+ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT = str
+ACTIVITY_SCHEDULE_TO_START_TIMEOUT = str
+ACTIVITY_HEARTBEAT_TIMEOUT = str
+
+LOGGING = dict

--- a/simpleflow/settings/default.py
+++ b/simpleflow/settings/default.py
@@ -1,0 +1,32 @@
+import logging
+
+
+WORKFLOW_DEFAULT_TASK_LIST = 'default'
+WORKFLOW_DEFAULT_VERSION = 'default'
+WORKFLOW_DEFAULT_EXECUTION_TIME = str(60 * 60)  # 1 hour.
+WORKFLOW_DEFAULT_DECISION_TASK_TIMEOUT = str(5 * 60)  # 5 minutes.
+
+ACTIVITY_DEFAULT_TASK_LIST = 'default'
+ACTIVITY_DEFAULT_VERSION = 'default'
+ACTIVITY_DEFAULT_TIMEOUT = str(5 * 60)  # 5 minutes.
+ACTIVITY_START_TO_CLOSE_TIMEOUT = ACTIVITY_DEFAULT_TIMEOUT
+ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT = ACTIVITY_DEFAULT_TIMEOUT
+ACTIVITY_SCHEDULE_TO_START_TIMEOUT = ACTIVITY_DEFAULT_TIMEOUT
+ACTIVITY_HEARTBEAT_TIMEOUT = ACTIVITY_DEFAULT_TIMEOUT
+
+LOGGING = {
+    'version': 1,
+    'loggers': {
+        'simpleflow': {
+            'level': 'INFO',
+            'handlers': ['console'],
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'stream': 'ext://sys.stderr',
+        },
+    },
+}

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -133,8 +133,10 @@ class Executor(executor.Executor):
         elif state == 'failed':
             future._state = futures.FINISHED
             future._exception = exceptions.TaskFailed(
+                name=event['id'],
                 reason=event['reason'],
-                details=event['details'])
+                details=event.get('details'),
+            )
         elif state == 'timed_out':
             future._state = futures.FINISHED
             future._exception = exceptions.TimeoutError(
@@ -262,25 +264,57 @@ class Executor(executor.Executor):
         ``*args`` and ``**kwargs`` must be serializable in JSON.
 
         """
+        errors = []
+        arguments = []
+        keyword_arguments = {}
+        result = None
         try:
-            args = [executor.get_actual_value(arg) for arg in args]
-            kwargs = {key: executor.get_actual_value(val) for
-                      key, val in kwargs.iteritems()}
+            for arg in args:
+                if isinstance(arg, futures.Future) and arg.failed:
+                    exc = arg._exception
+                    if isinstance(exc, exceptions.MultipleExceptions):
+                        errors.extend(exc.exceptions)
+                    else:
+                        errors.append(exc)
+                else:
+                    arguments.append(executor.get_actual_value(arg))
+
+            for key, val in kwargs.iteritems():
+                if isinstance(val, futures.Future) and val.failed:
+                    exc = val._exception
+                    if isinstance(exc, exceptions.MultipleExceptions):
+                        errors.extend(exc.exceptions)
+                    else:
+                        errors.append(val._exception)
+                else:
+                    keyword_arguments[key] = executor.get_actual_value(val)
+
         except exceptions.ExecutionBlocked:
-            return futures.Future()
+            result = futures.Future()
+        finally:
+            if errors:
+                result = futures.Future()
+                result._state = futures.FINISHED
+                result._exception = exceptions.MultipleExceptions(
+                    'futures failed',
+                    errors,
+                )
+            if result is not None:
+                return result
 
         try:
             if isinstance(func, Activity):
-                task = self.make_activity_task(func, *args, **kwargs)
+                make_task = self.make_activity_task
             elif issubclass(func, Workflow):
-                task = self.make_workflow_task(func, *args, **kwargs)
+                make_task = self.make_workflow_task
             else:
                 raise TypeError
+            task = make_task(func, *arguments, **keyword_arguments)
         except TypeError:
             raise TypeError('invalid type {} for {}'.format(
                 type(func), func))
 
-        return self.resume(task, *args, **kwargs)
+        return self.resume(task, *arguments, **keyword_arguments)
 
     def map(self, callable, iterable):
         """Submit *callable* with each of the items in ``*iterables``.

--- a/simpleflow/swf/process/__init__.py
+++ b/simpleflow/swf/process/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from .actor import Poller
+from .decider import Decider

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -290,6 +290,9 @@ class Poller(NamedMixin, swf.actors.Actor):
                 task_list,
                 identity=identity,
             )
+        except swf.exceptions.PollTimeout:
+            logger.debug('{}: PollTimeout'.format(self))
+            raise
         except Exception as err:
             logger.error(
                 "exception %s when polling on %s",

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -1,13 +1,16 @@
-import os
-import multiprocessing
-import signal
-import logging
+import abc
 import functools
 import getpass
 import json
-import abc
+import logging
+import multiprocessing
+import os
+import platform
+import signal
+import sys
 
-import faulthandler
+if platform.python_implementation().lower() != 'pypy':
+    import faulthandler
 from setproctitle import setproctitle
 
 import swf.actors
@@ -118,7 +121,8 @@ class Supervisor(object):
             self.is_alive = False
             self.stop(graceful=True)
 
-        faulthandler.enable()
+        if 'faulthandler' in sys.modules:
+            faulthandler.enable()
         signal.signal(signal.SIGTERM, signal_graceful_shutdown)
         signal.signal(signal.SIGINT, signal_graceful_shutdown)
 

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -1,0 +1,300 @@
+import os
+import multiprocessing
+import signal
+import logging
+import functools
+import getpass
+import json
+import abc
+
+import faulthandler
+from setproctitle import setproctitle
+
+import swf.actors
+
+from simpleflow import utils
+
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ['Supervisor', 'Poller']
+
+
+def get_hostname():
+    import socket
+
+    return socket.gethostname()
+
+
+def reset_signal_handlers(func):
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        return func(*args, **kwargs)
+
+    wrapped.__wrapped__ = func
+    return wrapped
+
+
+def with_state(state):
+    def wrapper(method):
+        @functools.wraps(method)
+        def wrapped(self, *args, **kwargs):
+            self.state = state
+            return method(self, *args, **kwargs)
+
+        wrapped.__wrapped__ = method
+        return wrapped
+    return wrapper
+
+
+def get_payload_name(payload):
+    import types
+
+    if isinstance(payload, types.MethodType):
+        instance = payload.im_self
+        return '{}.{}'.format(instance.__class__.__name__, payload.func_name)
+    elif isinstance(payload, types.FunctionType):
+        return payload.func_name
+
+    raise TypeError('invalid payload type {}'.format(type(payload)))
+
+
+class Supervisor(object):
+    def __init__(self, payload, arguments=None, nb_children=None):
+        self._nb_children = nb_children or multiprocessing.cpu_count()
+        self._processes = []
+        self._payload = payload
+        self._args = arguments if arguments is not None else ()
+
+    def start(self):
+        logger.info('starting {}'.format(self._payload))
+        setproctitle('{}(payload={})'.format(
+            self.__class__.__name__,
+            get_payload_name(self._payload),
+        ))
+        assert len(self._processes) == 0
+        for _ in xrange(self._nb_children):
+            child = multiprocessing.Process(
+                target=self._payload,
+                args=self._args,
+            )
+            child.start()
+            self._processes.append(child)
+        for proc in self._processes:
+            proc.join()
+
+    def stop(self):
+        assert len(self._processes) > 0
+        self._processes = []
+
+    def restart(self):
+        self.stop()
+        self.start()
+
+    def bind_signal_handlers(self):
+        """Binds signals for graceful shutdown.
+
+        - SIGTERM and SIGINT lead to a graceful shutdown.
+        - SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL displays a traceback
+          using the faulthandler library.
+
+        """
+        def signal_graceful_shutdown(signum, frame):
+            """
+            Note: Function is nested to have a reference to *self*.
+
+            """
+            if not self.is_alive:
+                return
+
+            logger.info(
+                'signal %d caught. Shutting down %s',
+                signum,
+                self.name,
+            )
+            self.is_alive = False
+            self.stop(graceful=True)
+
+        faulthandler.enable()
+        signal.signal(signal.SIGTERM, signal_graceful_shutdown)
+        signal.signal(signal.SIGINT, signal_graceful_shutdown)
+
+
+class NamedMixin(object):
+    def __init__(self, name='', state='initializing'):
+        self._name = name
+        self._state = state
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, value):
+        self._state = value
+        self.set_process_name()
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+        self.set_process_name()
+
+    def set_process_name(self, name=None):
+        if name is None:
+            name = self.name
+
+        setproctitle('{}[{}]'.format(name, self.state))
+
+
+class Poller(NamedMixin, swf.actors.Actor):
+    """Multi-processing implementation of a SWF actor.
+
+    """
+    def __init__(self,
+                 domain,
+                 task_list=None,
+                 *args, **kwargs):
+        self.is_alive = False
+        swf.actors.Actor.__init__(self, domain, task_list)
+        super(Poller, self).__init__(
+            domain,
+            task_list,
+            *args,
+            **kwargs
+        )
+
+    @property
+    def identity(self):
+        """Identity when polling decision task.
+
+        http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html
+
+        Identity of the decider making the request, which is recorded in the
+        DecisionTaskStarted event in the workflow history. This enables
+        diagnostic tracing when problems arise. The form of this identity is
+        user defined. Minimum length of 0. Maximum length of 256.
+
+        """
+        return json.dumps({
+            'user': getpass.getuser(),   # system's user.
+            'hostname': get_hostname(),  # Main hostname.
+            'pid': os.getpid(),          # Current pid.
+        })[:256]  # May truncate value to fit with SWF limits.
+
+    def stop_gracefully(self, join_timeout=60):
+        self._worker.join(join_timeout)
+
+    def stop_forcefully(self):
+        self._worker.terminate()
+
+    @with_state('running')
+    def start(self):
+        """
+        Start the main decider process. There is no daemonization. The process
+        is intented to be run inside a supervisor process.
+
+        """
+        logger.info("starting %s on domain %s", self.name, self.domain.name)
+        self.set_process_name()
+        while self.is_alive:
+            try:
+                task = self._poll(self.task_list, self.identity)
+            except swf.exceptions.PollTimeout:
+                continue
+            self.process(task)
+
+    @with_state('stopping')
+    def stop(self, graceful=True, join_timeout=60):
+        """Stop the actor processes and subprocesses.
+
+        :param graceful: wait for children processes?
+        :type  graceful: bool.
+        :param join_timeout: maximum time to wait for children.
+        :type  join_timeout: int.
+        """
+        logger.info('stopping %s', self.name)
+        self.is_alive = False  # No longer take requests.
+
+        if graceful:
+            self.stop_gracefully(join_timeout)
+        else:
+            self.stop_forcefully()
+
+    @with_state('completing task')
+    def _complete(self, token, response):
+        try:
+            complete = utils.retry.with_delay(
+                nb_times=self.nb_retries,
+                delay=utils.retry.exponential,
+                log_with=logger.exception,
+            )(self.complete)  # Exponential backoff on errors.
+            complete(token, response)
+        except Exception as err:
+            # This embarasing because the decider cannot notify SWF of the
+            # task completion. As it will not try again, the task will
+            # timeout (start_to_complete).
+            logger.exception("cannot complete task: %s", str(err))
+
+    @abc.abstractmethod
+    def poll(self, task_list, identity):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def complete(self, token, task):
+        raise NotImplementedError
+
+    @with_state('polling')
+    def _poll(self, task_list=None, identity=None):
+        """
+        Polls a task represented by its token and data. It uses long-polling
+        with a timeout of one minute.
+
+        :param task_list: when set, it overrides the workflow's default task
+                          list. The specified string must not start or end with
+                          whitespace. It must not contain a : (colon), /
+                          (slash), | (vertical bar), or any control characters
+                          (\u0000-\u001f | \u007f - \u009f). Also, it must not
+                          contain the literal string "arn".
+
+        :type  task_list: str.
+        :param identity: when set, it overrides the default decider's identity.
+                         Identity of the decider making the request, which is
+                         recorded in the DecisionTaskStarted event in the
+                         workflow history. This enables diagnostic tracing when
+                         problems arise. The form of this identity is user
+                         defined. Minimum length of 0. Maximum length of 256.
+        :type  identity: str.
+
+        See also http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html#API_PollForDecisionTask_RequestSyntax
+
+        :returns:
+            :rtype: (str, swf.models.History)
+
+        """
+        if task_list is None and self.task_list:
+            task_list = self.task_list
+
+        if identity is None and self.identity:
+            identity = self.identity
+
+        logger.debug("polling decision task on %s", task_list)
+        try:
+            task = self.poll(
+                task_list,
+                identity=identity,
+            )
+        except Exception as err:
+            logger.error(
+                "exception %s when polling on %s",
+                str(err),
+                task_list,
+            )
+            raise
+        return task

--- a/simpleflow/swf/process/decider/__init__.py
+++ b/simpleflow/swf/process/decider/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+from .base import Decider, DeciderPoller, DeciderWorker
+from . import command

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -112,13 +112,12 @@ class DeciderPoller(swf.actors.Decider, Poller):
     def process(self, task):
         token, history = task
 
+        logger.info('taking decision for workflow {}'.format(
+            self._workflow_name))
+        decisions = self.decide(history)
         try:
-            decisions = self.decide(history)
-        except Exception as err:
-            logger.error('cannot take decision: {}'.format(err))
-            return
-
-        try:
+            logger.info('completing decision for workflow {}'.format(
+                self._workflow_name))
             self._complete(token, decisions)
         except Exception as err:
             logger.error('cannot complete decision: {}'.format(err))

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -1,0 +1,153 @@
+from __future__ import absolute_import
+
+import logging
+
+import swf.actors
+import swf.exceptions
+
+from simpleflow.swf.process.actor import (
+    Supervisor,
+    Poller,
+    with_state,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Decider(Supervisor):
+    def __init__(self, poller, nb_children=None):
+        self._poller = poller
+        self._poller.is_alive = True
+        Supervisor.__init__(
+            self,
+            payload=self._poller.start,
+            nb_children=nb_children,
+        )
+
+
+class DeciderPoller(swf.actors.Decider, Poller):
+    def __init__(self, workflows, domain, task_list, nb_retries=3,
+                 *args, **kwargs):
+        """
+        The decider is an actor that reads the full history of the workflow
+        execution and decides what happens next. The :class:`DeciderPoller`
+        polls decision tasks from a task list and send them to a worker that
+        returns one or several decisions.  A decision is for example scheduling
+        an activity or completing the workflow execution.
+
+        SWF ensures that only one decider gets a decision task for a workflow
+        execution. A decider is stateless because it takes decisions solely
+        based upon the history that comes with the decision task.
+
+        This implementation polls a single task list within a single domain.
+        It can handle several workflows on the same task list. The rationale
+        behind this is to limit operational burden by having a single service
+        handling multiple workflows.
+
+        :param workflows: that handles workflow executions.
+        :type  workflows: [simpleflow.swf.Executor].
+
+        """
+        self._workflow_name = '{}'.format(','.join([
+            ex._workflow.name for ex in workflows
+        ]))
+
+        # Maps a workflow's name to its definition.
+        # Used to dispatch a decision task to the corresponding workflow.
+        self._workflows = {
+            executor._workflow.name: executor for executor in workflows
+        }
+
+        # All executors must have the same domain and task list.
+        for ex in workflows[1:]:
+            if ex.domain.name != domain.name:
+                raise ValueError(
+                    'all workflows must be in the same domain "{}"'.format(
+                        domain.name))
+            elif ex._workflow.task_list != task_list:
+                raise ValueError(
+                    'all workflows must have the same task list "{}"'.format(
+                        task_list))
+
+        self.nb_retries = nb_retries
+
+        Poller.__init__(
+            self,
+            domain,
+            task_list,
+            *args,    # directly forward them.
+            **kwargs  # directly forward them.
+        )
+
+    def __repr__(self):
+        return '{cls}({domain}, {task_list}, {workflows})'.format(
+            cls=self.__class__.__name__,
+            domain=self.domain.name,
+            task_list=self.task_list,
+            workflows=','.join(self._workflows),
+        )
+
+    @property
+    def name(self):
+        """
+        The main purpose of this property is to find what workflow a decider
+        handles.
+
+        """
+        if self._workflow_name:
+            suffix = '(workflow={})'.format(self._workflow_name)
+        else:
+            suffix = ''
+        return '{}{}'.format(self.__class__.__name__, suffix)
+
+    @with_state('polling')
+    def poll(self, task_list, identity):
+        return swf.actors.Decider.poll(self, task_list, identity)
+
+    @with_state('completing decision task')
+    def complete(self, token, decisions):
+        return swf.actors.Decider.complete(self, token, decisions)
+
+    def process(self, task):
+        token, history = task
+
+        decisions = self.decide(history)
+        self._complete(token, decisions)
+
+    @with_state('deciding')
+    def decide(self, history):
+        worker = DeciderWorker(self._workflows)
+        decisions = worker.decide(history)
+        return decisions
+
+
+class DeciderWorker(object):
+    def __init__(self, workflows):
+        self._workflow_name = None
+        self._workflows = workflows
+
+    def decide(self, history):
+        """
+        Delegate the decision to the executor.
+
+        :param history: of the workflow execution.
+        :type  history: swf.models.History.
+        :returns:
+            :rtype: (str, [swf.models.decision.base.Decision])
+
+        """
+        self._workflow_name = history[0].workflow_type['name']
+        workflow_executor = self._workflows[self._workflow_name]
+        try:
+            decisions = workflow_executor.replay(history)
+            if isinstance(decisions, tuple) and len(decisions) == 2:  # (decisions, context)
+                decisions = decisions[0]
+        except Exception as err:
+            message = "workflow decision failed: {}".format(err)
+            logger.error(message)
+            decision = swf.models.decision.WorkflowExecutionDecision()
+            decision.fail(reason=swf.format.reason(message))
+            decisions = [decision]
+
+        return decisions

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -112,8 +112,16 @@ class DeciderPoller(swf.actors.Decider, Poller):
     def process(self, task):
         token, history = task
 
-        decisions = self.decide(history)
-        self._complete(token, decisions)
+        try:
+            decisions = self.decide(history)
+        except Exception as err:
+            logger.error('cannot take decision: {}'.format(err))
+            return
+
+        try:
+            self._complete(token, decisions)
+        except Exception as err:
+            logger.error('cannot complete decision: {}'.format(err))
 
     @with_state('deciding')
     def decide(self, history):

--- a/simpleflow/swf/process/decider/command.py
+++ b/simpleflow/swf/process/decider/command.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from . import helpers
 
 
-def start(workflows, domain, task_list, log_level, nb_processes):
+def start(workflows, domain, task_list, log_level=None, nb_processes=None):
     decider = helpers.make_decider(workflows, domain, task_list, nb_processes)
     decider.is_alive = True
     decider.start()

--- a/simpleflow/swf/process/decider/command.py
+++ b/simpleflow/swf/process/decider/command.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+from . import helpers
+
+
+def start(workflows, domain, task_list, log_level, nb_processes):
+    decider = helpers.make_decider(workflows, domain, task_list, nb_processes)
+    decider.is_alive = True
+    decider.start()

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -1,0 +1,32 @@
+import swf.models
+
+from simpleflow.swf.executor import Executor
+from . import (
+    Decider,
+    DeciderPoller,
+)
+
+
+def load_workflow(domain, workflow_name):
+    module_name, object_name = workflow_name.rsplit('.', 1)
+    module = __import__(module_name, fromlist=['*'])
+
+    workflow = getattr(module, object_name)
+    return Executor(swf.models.Domain(domain), workflow)
+
+
+def make_decider_poller(workflows, domain, task_list):
+    """
+    Factory to build a decider.
+
+    """
+    executors = [
+        load_workflow(domain, workflow) for workflow in workflows
+    ]
+    domain = swf.models.Domain(domain)
+    return DeciderPoller(executors, domain, task_list)
+
+
+def make_decider(workflows, domain, task_list, nb_children=None):
+    poller = make_decider_poller(workflows, domain, task_list)
+    return Decider(poller, nb_children=nb_children)

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -7,12 +7,12 @@ from . import (
 )
 
 
-def load_workflow(domain, workflow_name):
+def load_workflow(domain, workflow_name, task_list=None):
     module_name, object_name = workflow_name.rsplit('.', 1)
     module = __import__(module_name, fromlist=['*'])
 
     workflow = getattr(module, object_name)
-    return Executor(swf.models.Domain(domain), workflow)
+    return Executor(swf.models.Domain(domain), workflow, task_list)
 
 
 def make_decider_poller(workflows, domain, task_list):
@@ -21,7 +21,7 @@ def make_decider_poller(workflows, domain, task_list):
 
     """
     executors = [
-        load_workflow(domain, workflow) for workflow in workflows
+        load_workflow(domain, workflow, task_list) for workflow in workflows
     ]
     domain = swf.models.Domain(domain)
     return DeciderPoller(executors, domain, task_list)

--- a/simpleflow/swf/process/worker/__init__.py
+++ b/simpleflow/swf/process/worker/__init__.py
@@ -1,0 +1,1 @@
+import command

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -106,7 +106,7 @@ class ActivityWorker(object):
     def __init__(self, task_list, workflow):
         self._dispatcher = from_task_registry.RegistryDispatcher(
             simpleflow.task.registry,
-            task_list,
+            None,
             workflow,
         )
 

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -1,0 +1,144 @@
+import logging
+import multiprocessing
+import os
+import json
+
+import swf.actors
+import swf.format
+
+from simpleflow.swf.process.actor import (
+    MultiProcessActor,
+)
+from simpleflow.utils import retry
+
+
+logger = logging.getLogger(__name__)
+
+
+class Worker(swf.actors.ActivityWorker, MultiProcessActor):
+    def __init__(self, domain, task_list,
+                 dispatcher=DEFAULT_DISPATCHER,
+                 heartbeat_interval=50,
+                 nb_children=None,
+                 *args, **kwargs):
+        self.dispatcher = dispatcher
+        self._heartbeat_interval = heartbeat_interval
+
+        MultiProcessActor.__init__(
+            self,
+            domain,
+            task_list,
+            nb_children=nb_children,
+            *args,    # directly forward them.
+            **kwargs  # directly forward them.
+        )
+
+    @property
+    def state_self(self):
+        return self._state
+
+    @property
+    def name(self):
+        if self._task:
+            suffix = ':'.format(self._task.activity_id)
+        else:
+            suffix = ''
+        return '{}(domain={}, task_list={}){}'.format(
+            self.__class__.__name__,
+            self.domain,
+            self.task_list,
+            suffix,
+        )
+
+    def fail(self, task, token, reason=None, details=None):
+        try:
+            return swf.actors.ActivityWorker.fail(
+                self,
+                token,
+                reason=swf.format.reason(reason),
+                details=swf.format.details(details),
+            )
+        except Exception as err:
+            logger.error('cannot fail task {}: {}'.format(
+                task.activity_type.name,
+                err,
+            ))
+
+    def dispatch(self, task):
+        name = task.activity_type.name
+        return self.dispatcher.dispatch(name)
+
+    def process_task(self, task):
+        handler = self.dispatch(task)
+        input = json.loads(task.input)
+        args = input.get('args', ())
+        kwargs = input.get('kwargs', {})
+        return handler(*args, **kwargs)
+
+    @reset_signal_handlers
+    @will_release_semaphore
+    def handle_activity_task(self, task_list=None):
+        """
+        Happens in a subprocess. Polls and make decisions with respect to the
+        current state of the workflow execution represented by its history.
+
+        """
+        self.state = 'polling'
+        try:
+            token, task= self.poll(task_list)
+        except swf.exceptions.PollTimeout:
+            # TODO(ggreg) move this out of the task handling logic.
+            self._children_processes.remove(os.getpid())
+            return
+
+        self.state = 'processing'
+        try:
+            result = self.process_task(task)
+        except Exception as err:
+            message = "activity task failed: {}".format(err)
+            logger.error(message)
+            decision = swf.models.decision.WorkflowExecutionDecision()
+            self.fail(reason=swf.format.reason(message))
+            decisions = [decision]
+
+        try:
+            self.state = 'completing'
+            complete = retry.with_delay(
+                nb_times=self.nb_retries,
+                delay=retry.exponential,
+                logger=logger,
+            )(self.complete)  # Exponential backoff on errors.
+            complete(token, decisions)
+        except Exception as err:
+            # This is embarassing because the worker cannot notify SWF of the
+            # task completion. As it will not try again, the activity task will
+            # timeout (start_to_complete).
+            logger.error("cannot complete activity task: %s", str(err))
+
+        # TODO(ggreg) move this out of the decision handling logic.
+        # This cannot work because it is executed in a subprocess.
+        # Hence it does not share the parent's object.
+        self._children_processes.remove(os.getpid())
+
+    def spawn_handler(self):
+        try:
+            self._semaphore.acquire()
+        except OSError as err:
+            logger.warning("cannot acquire semaphore: %s", str(err))
+
+        if self.is_alive:
+            process = multiprocessing.Process(target=self.handle_activity_task)
+            process.start()
+            # This is needed to wait for children when stopping the main
+            # decider process.
+            self._children_processes.add(process)
+
+    def start(self):
+        logger.info(
+            'starting %s on domain %s',
+            self.name,
+            self.domain.name,
+        )
+        self.set_process_name()
+        while self.is_alive():
+            self.spawn_handler()

--- a/simpleflow/swf/process/worker/command.py
+++ b/simpleflow/swf/process/worker/command.py
@@ -18,7 +18,7 @@ def make_worker_poller(workflow, domain, task_list):
     )
 
 
-def start(workflow, domain, task_list, nb_processes):
+def start(workflow, domain, task_list, nb_processes=None):
     poller = make_worker_poller(workflow, domain, task_list)
     worker = Worker(poller)
     worker.is_alive = True

--- a/simpleflow/swf/process/worker/command.py
+++ b/simpleflow/swf/process/worker/command.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+import swf.models
+
+from simpleflow.swf.process.decider import helpers
+from .base import (
+    Worker,
+    ActivityPoller,
+)
+
+
+def make_worker_poller(workflow, domain, task_list):
+    domain = swf.models.Domain(domain)
+    return ActivityPoller(
+        domain,
+        task_list,
+        helpers.load_workflow(domain, workflow),
+    )
+
+
+def start(workflow, domain, task_list, nb_processes):
+    poller = make_worker_poller(workflow, domain, task_list)
+    worker = Worker(poller)
+    worker.is_alive = True
+    worker.start()

--- a/simpleflow/swf/process/worker/dispatch/__init__.py
+++ b/simpleflow/swf/process/worker/dispatch/__init__.py
@@ -1,0 +1,3 @@
+import by_module
+import from_task_registry
+import dry_run

--- a/simpleflow/swf/process/worker/dispatch/by_module.py
+++ b/simpleflow/swf/process/worker/dispatch/by_module.py
@@ -1,0 +1,26 @@
+from . import exceptions
+
+
+class ModuleDispatcher(object):
+    def __init__(self, mod, mapping=None):
+        self._module = mod
+        self._mapping = mapping
+
+    def dispatch(self, name):
+        """
+        Dispatch a *name* to a *function* by finding a module to load.
+
+        It parses *name* as ``{module}.{function}`` and returns a function
+        object.
+
+        """
+        submodule_name, func_name = name.rsplit('.', 1)
+        if self._mapping is not None:
+            try:
+                submodule_name = self._mapping[submodule_name]
+            except KeyError:
+                raise exceptions.DispatchError('cannot dispatch {}'.format(
+                                               name))
+
+        submodule = getattr(self._module, submodule_name)
+        return getattr(submodule, func_name)

--- a/simpleflow/swf/process/worker/dispatch/dry_run.py
+++ b/simpleflow/swf/process/worker/dispatch/dry_run.py
@@ -1,0 +1,7 @@
+def do_nothing(*args, **kwargs):
+    return {}
+
+
+class DryRunDispatcher(object):
+    def dispatch(self, name):
+        return do_nothing

--- a/simpleflow/swf/process/worker/dispatch/exceptions.py
+++ b/simpleflow/swf/process/worker/dispatch/exceptions.py
@@ -1,0 +1,2 @@
+class DispatchError(Exception):
+    pass

--- a/simpleflow/swf/process/worker/dispatch/from_task_registry.py
+++ b/simpleflow/swf/process/worker/dispatch/from_task_registry.py
@@ -1,0 +1,31 @@
+class RegistryDispatcher(object):
+    """
+    Map a name to a task handler wrt a task registry.
+
+    The registry has the format ``{label: {name: task}}``.
+
+    """
+    def __init__(self, registry, label, workflow):
+        """
+
+        :param registry: of tasks.
+        :type  registry: {str: {str: Task}}
+        :param label: name of the task list.
+        :type  label: str.
+        :param workflow: definition.
+        :type workflow: Workflow.
+
+        """
+        self._registry = registry
+        self._label = label
+
+    def dispatch(self, name):
+        """
+        :param name: of the task to dispatch.
+        :type  name: str.
+
+        :returns:
+            :rtype: callable.
+
+        """
+        return self._registry[self._label][name]._callable

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -4,7 +4,7 @@ from simpleflow import task
 
 
 class ActivityTask(task.ActivityTask):
-    def schedule(self, domain):
+    def schedule(self, domain, task_list=None, **kwargs):
         activity = self.activity
         # Always involve a GET call to the SWF API which introduces useless
         # latency if the ActivityType already exists.
@@ -19,23 +19,43 @@ class ActivityTask(task.ActivityTask):
             'kwargs': self.kwargs,
         }
 
+        if task_list is None:
+            task_list = activity.task_list
+        task_timeout = kwargs.get(
+            'task_timeout',
+            str(activity.task_start_to_close_timeout),
+        )
+        duration_timeout = kwargs.get(
+            'duration_timeout',
+            str(activity.task_schedule_to_close_timeout),
+        )
+        schedule_timeout = kwargs.get(
+            'schedule_timeout',
+            str(activity.task_schedule_to_start_timeout),
+        )
+        heartbeat_timeout = kwargs.get(
+            'heartbeat_timeout',
+            str(activity.task_heartbeat_timeout),
+        )
+
         decision = swf.models.decision.ActivityTaskDecision(
             'schedule',
             activity_id=self.id,
             activity_type=model,
             control=None,
-            task_list=activity.task_list,
+            task_list=task_list,
             input=input,
-            task_timeout=str(activity.task_start_to_close_timeout),
-            duration_timeout=str(activity.task_schedule_to_close_timeout),
-            schedule_timeout=str(activity.task_schedule_to_start_timeout),
-            heartbeat_timeout=str(activity.task_heartbeat_timeout))
+            task_timeout=task_timeout,
+            duration_timeout=duration_timeout,
+            schedule_timeout=schedule_timeout,
+            heartbeat_timeout=heartbeat_timeout,
+        )
 
         return [decision]
 
 
 class WorkflowTask(task.WorkflowTask):
-    def schedule(self, domain):
+    def schedule(self, domain, task_list=None):
         workflow = self.workflow
         # Always involve a GET call to the SWF API which introduces useless
         # latency if the WorkflowType already exists.

--- a/simpleflow/swf/utils.py
+++ b/simpleflow/swf/utils.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+import swf.models
+import swf.querysets
+
+from simpleflow.history import History
+
+
+def get_workflow_history(domain_name, workflow_id, run_id):
+    domain = swf.models.Domain(domain_name)
+    workflow_execution = (
+        swf.querysets.WorkflowExecutionQuerySet(domain).get(
+            workflow_id=workflow_id,
+            run_id=run_id,
+        )
+    )
+
+    return History(workflow_execution.history())

--- a/simpleflow/utils/__init__.py
+++ b/simpleflow/utils/__init__.py
@@ -1,0 +1,1 @@
+from . import retry

--- a/simpleflow/utils/retry.py
+++ b/simpleflow/utils/retry.py
@@ -1,0 +1,66 @@
+import time
+import collections
+import functools
+import logging
+
+
+def constant(value):
+    @functools.wraps(constant)
+    def call(*args, **kwargs):
+        return value
+
+    return call
+
+
+def exponential(value):
+    import random
+
+    return random.random() * (2 ** value)
+
+
+def with_delay(
+        nb_times=1,
+        delay=constant(1),
+        on_exceptions=Exception,
+        log_with=None):
+    """
+    Retry the *decorated* function *nb_times* with a *delay*.
+
+    :param nb_times: number of times to retry.
+    :type  nb_times: int
+
+    :param delay: to wait before the next retry (also called back-off).
+    :type  delay: callable(value: int) -> int
+
+    :param on_exceptions: retry only when these exceptions raise.
+    :type  on_exceptions: Sequence([Exception])
+
+    """
+    if log_with is None:
+        log_with = logging.getLogger(__name__).info
+
+    def decorate(func):
+        @functools.wraps(func)
+        def decorated(*args, **kwargs):
+            nb_retries = 0
+            while nb_times - nb_retries:
+                try:
+                    return func(*args, **kwargs)
+                except on_exceptions as error:
+                    wait_delay = delay(nb_retries)
+                    log_with(
+                        'error "%s": retrying in %d seconds',
+                        error,
+                        wait_delay,
+                    )
+                    time.sleep(wait_delay)
+                    nb_retries += 1
+            raise
+        return decorated
+
+    if not isinstance(on_exceptions, collections.Sequence):
+        on_exceptions = tuple([on_exceptions])
+    elif not isinstance(on_exceptions, tuple):
+        on_exceptions = tuple(on_exceptions)
+
+    return decorate

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import swf.models
+
+from simpleflow import (
+    activity,
+    Workflow,
+    futures,
+)
+
+
+DOMAIN = swf.models.Domain('TestDomain')
+DEFAULT_VERSION = 'test'
+
+
+@activity.with_attributes(version=DEFAULT_VERSION)
+def increment(x):
+    return x + 1
+
+
+@activity.with_attributes(version=DEFAULT_VERSION)
+def double(x):
+    return x * 2
+
+
+class TestWorkflow(Workflow):
+    name = 'test_workflow'
+    version = 'test_version'
+    task_list = 'test_task_list'
+    decision_tasks_timeout = '300'
+    execution_timeout = '3600'
+    tag_list = None      # FIXME should be optional
+    child_policy = None  # FIXME should be optional
+
+
+class TestDefinition(TestWorkflow):
+    """
+    Executes two tasks. The second depends on the first.
+
+    """
+    def run(self):
+        a = self.submit(increment, 1)
+        assert isinstance(a, futures.Future)
+
+        b = self.submit(double, a)
+
+        return b.result

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -2,30 +2,12 @@ from simpleflow import activity
 
 
 @activity.with_attributes(task_list='test')
-def increment(x):
-    return x + 1
-
-
-@activity.with_attributes(task_list='test')
-def double(x):
-    return x * 2
-
-
-@activity.with_attributes(task_list='test')
-def square(x):
-    return x * x
+def dummy_test_task(x):
+    return x
 
 
 def test_task_register():
     from simpleflow import task
 
-    assert sorted(task.registry['test'].keys()) == sorted([
-        'tests.test_task.increment',
-        'tests.test_task.double',
-        'tests.test_task.square',
-    ])
-    assert sorted(task.registry['test'].values()) == sorted([
-        increment,
-        double,
-        square,
-    ])
+    assert 'tests.test_task.dummy_test_task' in task.registry[None].keys()
+    assert dummy_test_task in task.registry[None].values()


### PR DESCRIPTION
Add:

- Decider
- Worker
- *standalone* command

These changes provides the infrastructure to actually execute workflows with Amazon SWF. The *decider* process is responsible for handling decision tasks and the worker handles activity tasks. They both try to handle errors and some corner cases such as a worker subprocess that gets a `SIGKILL` signal from the linux OOM killer.

The *standalone* mode helps to test changes with an actual execution by managing all the necessary processes in a single command.