### PR TITLE
Fix command-line --local mode requiring SWF access 

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -76,6 +76,8 @@ def start(workflow,
 
         Executor(workflow_definition).run(input)
 
+        return
+
     if not domain:
         raise ValueError('*domain* must be set when not running in local mode')
 


### PR DESCRIPTION
I was curious to see if the local mode works, and it actually does with this tiny change. Hence this change makes simpleflow subway-compatible, yay! :train: 