### PR TITLE
Update command: make interface consistent

### DIFF
--- a/simpleflow/swf/stats/helpers.py
+++ b/simpleflow/swf/stats/helpers.py
@@ -8,7 +8,7 @@ from . import pretty
 
 
 __all__ = [
-    'show_workflow_stats',
+    'show_workflow_profile',
     'show_workflow_status',
     'list_workflow_executions',
 ]
@@ -40,13 +40,22 @@ def get_workflow_execution(domain_name, workflow_id, run_id=None):
     return workflow_execution
 
 
-def show_workflow_stats(domain_name, workflow_id, run_id=None, nb_tasks=None):
+def show_workflow_info(domain_name, workflow_id, run_id=None):
     workflow_execution = get_workflow_execution(
         domain_name,
         workflow_id,
         run_id,
     )
-    return pretty.show(workflow_execution, nb_tasks)
+    return pretty.info(workflow_execution)
+
+
+def show_workflow_profile(domain_name, workflow_id, run_id=None, nb_tasks=None):
+    workflow_execution = get_workflow_execution(
+        domain_name,
+        workflow_id,
+        run_id,
+    )
+    return pretty.profile(workflow_execution, nb_tasks)
 
 
 def show_workflow_status(domain_name, workflow_id, run_id=None, nb_tasks=None):


### PR DESCRIPTION
```sh
Usage: simpleflow [OPTIONS] COMMAND [ARGS]...

Options:
  --format TEXT
  --header / --no-header
  --help                  Show this message and exit.

Commands:
  info     about a workflow execution
  list     active workflow executions
  profile  the tasks of a workflow
  start    the workflow defined in the WORKFLOW module
  status   of a workflow execution
```

- Factor formatting in a decorator.
- Remove boilerplate from function.
- Separate responsibilities.
- Extract info in a dedicated command.
- Support multiple formats

The main purpose of these changes is to make it easier to add new commands. Each handler such as `pretty.list`, `pretty.info`, `pretty.profile`, `pretty.status`, follows the same interface and returns a `(header, rows)` tuple. This is what makes it easy to compose with `pretty.formatted`. There is however still some customization to support like settings `tablefmt` for the `tabular` format.

ping @jbbarth 