### PR TITLE
Make execute.python more resilient.

### DIFF
--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -5,9 +5,13 @@ import functools
 import json
 import cPickle as pickle
 import base64
+import logging
 
 
 __all__ = ['program', 'python']
+
+
+logger = logging.getLogger('simpleflow')
 
 
 class RequiredArgument(object):
@@ -169,14 +173,14 @@ def python(interpreter='python'):
                                     cls.strip(),
                                     msg.strip(),
                                 ))
-                            except:
-                                pass
+                            except BaseException as ex:
+                                logger.warning(ex.message)
 
                 raise exception
             try:
                 return json.loads(output)
-            except:
-                pass
+            except BaseException as ex:
+                logger.warning(ex.message)
 
         # Not automatically assigned in python < 3.2.
         execute.__wrapped__ = func

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -11,7 +11,7 @@ import logging
 __all__ = ['program', 'python']
 
 
-logger = logging.getLogger('simpleflow')
+logger = logging.getLogger(__name__)
 
 
 class RequiredArgument(object):

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import subprocess
 import functools
@@ -158,14 +159,24 @@ def python(interpreter='python'):
                     exception = pickle.loads(
                         base64.b64decode(excline.rstrip()))
                 except TypeError:
-                    cls, msg = exclines[-1].split(':', 1)
-                    exception = eval('{}("{}")'.format(
-                        cls.strip(),
-                        msg.strip(),
-                    ))
+                    excline = exclines[-1]
+                    exception = Exception(excline)
+                    if ':' in excline:
+                        cls, msg = excline.split(':', 1)
+                        if re.match(r'\s*[\w.]+\s*', cls):
+                            try:
+                                exception = eval('{}("{}")'.format(
+                                    cls.strip(),
+                                    msg.strip(),
+                                ))
+                            except:
+                                pass
 
                 raise exception
-            return json.loads(output)
+            try:
+                return json.loads(output)
+            except:
+                pass
 
         # Not automatically assigned in python < 3.2.
         execute.__wrapped__ = func

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -178,9 +178,10 @@ def python(interpreter='python'):
 
                 raise exception
             try:
-                return json.loads(output)
+                return json.loads(output.rstrip().rsplit("\n", 1)[-1])
             except BaseException as ex:
                 logger.warning(ex.message)
+                logger.warning(repr(output))
 
         # Not automatically assigned in python < 3.2.
         execute.__wrapped__ = func

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -125,6 +125,15 @@ def test_function_as_program_raises_builtin_exception():
         add('1')
 
 
+@execute.python()
+def print_string():
+    print "This isn't part of the return value"
+
+
+def test_function_with_print():
+    assert print_string() is None
+
+
 class DummyException(Exception):
     pass
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -3,7 +3,6 @@ import os.path
 
 import pytest
 
-from simpleflow import activity
 from simpleflow import execute
 
 
@@ -126,12 +125,21 @@ def test_function_as_program_raises_builtin_exception():
 
 
 @execute.python()
-def print_string():
-    print "This isn't part of the return value"
+def print_string(s, retval):
+    print s
+    return retval
 
 
 def test_function_with_print():
-    assert print_string() is None
+    assert print_string("This isn't part of the return value", None) is None
+
+
+def test_function_with_print_and_return():
+    assert print_string("This isn't part of the return value", 42) == 42
+
+
+def test_function_returning_lf():
+    assert print_string("This isn't part of the return value", "a\nb") == "a\nb"
 
 
 class DummyException(Exception):


### PR DESCRIPTION
This patch adds two robustness features to `execute.python`:

1. In case of error (non-zero interpreter return value), don't blindly try to
   `eval` the returned string.

   It may be e.g. `/usr/bin/python: Import by filename is not supported.`
   (simpleflow not installed in this Python environment).

   This code can be simplified; it's trying to lower the possibility of a
   malicious string eval'ed.

2. On a successful execution, we `json.loads` the function's stdout plus its
   return value. This is likely to fail if it prints anything (what to do here?)
