### PR TITLE
Fix simpleflow disabling other loggers when imported

### DIFF
--- a/simpleflow/settings/default.py
+++ b/simpleflow/settings/default.py
@@ -16,6 +16,7 @@ ACTIVITY_HEARTBEAT_TIMEOUT = ACTIVITY_DEFAULT_TIMEOUT
 
 LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'loggers': {
         'simpleflow': {
             'level': 'INFO',


### PR DESCRIPTION
Very small change, I'll merge if the build is green on Travis, and I'll release a simpleflow 0.9.1 this afternoon or tomorrow depending on other things I may find.