### PR TITLE
Add json output format

### DIFF
--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -1,4 +1,5 @@
 import sys
+import types
 import operator
 from functools import partial, wraps
 from datetime import datetime
@@ -57,12 +58,38 @@ def human(values, headers):
     )
 
 
+def _serialize_complex_object(obj):
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, types.GeneratorType):
+        return [i for i in obj]
+    raise TypeError(
+        "Type %s couldn't be serialized. This is a bug in simpleflow," \
+        " please file a new issue on GitHub!" % type(obj))
+
+
+def jsonify(values, headers):
+    import json
+
+    if headers:
+        return json.dumps(
+            [dict(zip(headers, value)) for value in values],
+            default=_serialize_complex_object,
+        )
+    else:
+        return json.dumps(
+            values,
+            default=_serialize_complex_object,
+        )
+
+
 DEFAULT_FORMAT = partial(tabular, tablefmt='plain', floatfmt='.2f')
 FORMATS = {
     'csv': csv,
     'tsv': partial(csv, delimiter='\t'),
     'tabular': DEFAULT_FORMAT,
     'human': human,
+    'json': jsonify,
 }
 
 


### PR DESCRIPTION
The idea behind this is to make integrations with other tools/languages easier. For now this is a bit hard to test, but I'll work to make tests a bit easier.

The basic idea as for headers is to generate simple lists if the `--header` option isn't here, and hashes/dicts else. For instance:
```
% simpleflow --format json workflow.profile TestDomain update-1.0-1442747578|python -m json.tool
[
    [
        "activity-workflow.first_activity-1",
        "completed",
        "2015-09-20 13:13",
        0.037,
        "2015-09-20 13:13",
        5.508,
        "2015-09-20 13:13",
        63.12170524868209
    ],
...
```
VS
```
% simpleflow --header --format json workflow.profile TestDomain update-1.0-1442747578|python -m json.tool
[
    {
        "End": "2015-09-20 13:13",
        "Last State": "completed",
        "Percentage of total time": 63.12170524868209,
        "Scheduled": "2015-09-20 13:13",
        "Start": "2015-09-20 13:13",
        "Task": "activity-workflow.first_activity-1",
        "Time Running": 5.508,
        "Time Scheduled": 0.037
    },
...
```

What do you think @ybastide ?