### PR TITLE
Generate a safer task ID for idempotent tasks

### DIFF
--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -15,6 +15,7 @@ def with_attributes(
         schedule_to_close_timeout=settings.ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
         schedule_to_start_timeout=settings.ACTIVITY_SCHEDULE_TO_START_TIMEOUT,
         heartbeat_timeout=settings.ACTIVITY_HEARTBEAT_TIMEOUT,
+        idempotent=None,
 ):
     """
     :param name: of the activity type.
@@ -29,7 +30,8 @@ def with_attributes(
             start_to_close_timeout,
             schedule_to_close_timeout,
             schedule_to_start_timeout,
-            heartbeat_timeout
+            heartbeat_timeout,
+            idempotent=idempotent,
         )
 
     return wrap
@@ -45,7 +47,8 @@ class Activity(object):
                  start_to_close_timeout=None,
                  schedule_to_close_timeout=None,
                  schedule_to_start_timeout=None,
-                 heartbeat_timeout=None):
+                 heartbeat_timeout=None,
+                 idempotent=None):
         self._callable = callable
 
         self._name = name
@@ -53,6 +56,7 @@ class Activity(object):
         self.task_list = task_list
         self.retry = retry
         self.raises_on_failure = raises_on_failure
+        self.idempotent = idempotent
         self.task_start_to_close_timeout = start_to_close_timeout
         self.task_schedule_to_close_timeout = schedule_to_close_timeout
         self.task_schedule_to_start_timeout = schedule_to_start_timeout

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -31,6 +31,7 @@ class Task(object):
 class ActivityTask(Task):
     def __init__(self, activity, *args, **kwargs):
         self.activity = activity
+        self.idempotent = activity.idempotent
         self.args = args
         self.kwargs = kwargs
         self.id = None
@@ -51,6 +52,8 @@ class ActivityTask(Task):
 class WorkflowTask(Task):
     def __init__(self, workflow, *args, **kwargs):
         self.workflow = workflow
+        # TODO: handle idempotence at workflow level
+        self.idempotent = False
         self.args = args
         self.kwargs = kwargs
         self.id = None


### PR DESCRIPTION
This addresses a first sub-case for #11, see rationale there. Long story short, this makes workflows more robust for idempotent tasks (which is our primary case here at Botify, but might not always be the case for other use cases).

Ping @ampelmann @ybastide 