### PR TITLE
Fix optional activities failing workflow while they shouldn't

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -23,11 +23,6 @@ def delay(t, x):
     return x
 
 
-@activity.with_attributes(task_list='quickstart', version='example')
-def add(x, y):
-    return x + y
-
-
 class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
@@ -43,20 +38,3 @@ class BasicWorkflow(Workflow):
             result=z.result)
         futures.wait(yy, z)
         return z.result
-
-
-@activity.with_attributes(task_list='quickstart', version='example')
-def fail(x):
-    return fail
-
-
-class FailingWorkflow(Workflow):
-    name = 'failing'
-    version = 'example'
-    task_list = 'example'
-
-    def run(self, x):
-        y = self.submit(fail, x)
-        z = self.submit(fail, x)
-        output = self.submit(add, y, z)
-        return output.result

--- a/examples/failing.py
+++ b/examples/failing.py
@@ -1,0 +1,30 @@
+import time
+
+from simpleflow import (
+    activity,
+    Workflow,
+    futures,
+)
+
+
+@activity.with_attributes(task_list='quickstart', version='example',
+                          raises_on_failure=False)
+def fail_but_dont_raise():
+    raise ValueError("This task had a problem but it's okay, YOU SHOULD NOT SEE THIS")
+
+@activity.with_attributes(task_list='quickstart', version='example',
+                          raises_on_failure=True)
+def fail_and_raise():
+    raise ValueError("This task had a problem and it will fail the workflow! (this is normal if you see this)")
+
+
+class FailingWorkflow(Workflow):
+    name = 'failing'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self):
+        x = self.submit(fail_but_dont_raise)
+        y = self.submit(fail_and_raise)
+        futures.wait(x, y)
+        raise ValueError("YOU SHOULD NEVER SEE THIS")

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "BASIC WORKFLOW"
+(
+  set -x
+  simpleflow workflow.start --local examples.basic.BasicWorkflow --input '[3, 0]'
+)
+
+echo
+echo "FAILING WORKFLOW"
+(
+  set -x
+  simpleflow workflow.start --local examples.failing.FailingWorkflow --input '[]' 2>&1
+) | sed "/^ .*/d;s/^Traceback.*/<...snip...>/"

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -27,22 +27,26 @@ class TaskFailed(Exception):
     """
     Wrap the error's *reason* and *details* for an task that failed.
 
+    :param name: of the task that failed.
+    :type name: str.
     :param reason: of the failure.
     :type  reason: str.
     :param details: of the failure.
     :type  details: str.
 
     """
-    def __init__(self, reason, details=None):
-        super(TaskFailed, self).__init__(self, reason, details)
+    def __init__(self, name, reason, details=None):
+        super(TaskFailed, self).__init__(name, reason, details)
+        self.name = name
         self.reason = reason
         self.details = None
 
     def __repr__(self):
-        return '{}(reason="{}")'.format(
+        return '{} ({}, "{}")'.format(
             self.__class__.__name__,
+            self.name,
             self.reason,
-            self.details)
+        )
 
 
 class TimeoutError(Exception):

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -33,18 +33,16 @@ class TaskFailed(Exception):
     :type  details: str.
 
     """
-    def __init__(self, name, reason, details=None):
-        super(TaskFailed, self).__init__(name, reason, details)
-        self.name = name
+    def __init__(self, reason, details=None):
+        super(TaskFailed, self).__init__(self, reason, details)
         self.reason = reason
         self.details = None
 
     def __repr__(self):
-        return '{}({}, "{}")'.format(
+        return '{}(reason="{}")'.format(
             self.__class__.__name__,
-            self.name,
             self.reason,
-        )
+            self.details)
 
 
 class TimeoutError(Exception):
@@ -56,19 +54,3 @@ class TimeoutError(Exception):
         return '{}({})'.format(
             self.__class__.__name__,
             self.timeout_type)
-
-
-class MultipleExceptions(Exception):
-    def __init__(self, msg, exceptions):
-        super(MultipleExceptions, self).__init__(msg, exceptions)
-        self.exceptions = exceptions
-
-    def __repr__(self):
-        return '{}({}, {})'.format(
-            self.__class__.__name__,
-            self.msg,
-            ', '.join(str(exc) for exc in self.exceptions),
-        )
-
-    def __unicode__(self):
-        return self.__repr__()

--- a/simpleflow/futures.py
+++ b/simpleflow/futures.py
@@ -81,9 +81,6 @@ class Future(object):
         if self._state != FINISHED:
             return self.wait()
 
-        if self._exception is not None:
-            raise self._exception
-
         return self._result
 
     def cancel(self):
@@ -129,10 +126,6 @@ class Future(object):
     @property
     def finished(self):
         return self._state == FINISHED
-
-    @property
-    def failed(self):
-        return self._state == FINISHED and self._exception is not None
 
     @property
     def done(self):

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -90,7 +90,7 @@ class History(object):
             activity = get_activity(event)
             activity['state'] = event.state
             activity['reason'] = event.reason
-            activity['details'] = event.details
+            activity['details'] = getattr(event, 'details', '')
             activity['failed_timestamp'] = event.timestamp
             if 'retry' not in activity:
                 activity['retry'] = 0

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -90,7 +90,7 @@ class History(object):
             activity = get_activity(event)
             activity['state'] = event.state
             activity['reason'] = event.reason
-            activity['details'] = getattr(event, 'details', '')
+            activity['details'] = event.details
             activity['failed_timestamp'] = event.timestamp
             if 'retry' not in activity:
                 activity['retry'] = 0

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -26,7 +26,8 @@ class Executor(executor.Executor):
             future._result = func._callable(*args, **kwargs)
         except Exception as err:
             future._exception = err
-            raise
+            if func.raises_on_failure:
+                raise
         finally:
             future._state = futures.FINISHED
 

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -1,6 +1,7 @@
 import logging
 
 from simpleflow import (
+    exceptions,
     executor,
     futures,
 )
@@ -27,7 +28,7 @@ class Executor(executor.Executor):
         except Exception as err:
             future._exception = err
             if func.raises_on_failure:
-                raise
+                raise exceptions.TaskFailed(func.name, err.message)
         finally:
             future._state = futures.FINISHED
 

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -144,8 +144,9 @@ class Executor(executor.Executor):
         elif state == 'failed':
             future._state = futures.FINISHED
             future._exception = exceptions.TaskFailed(
+                name=event['id'],
                 reason=event['reason'],
-                details=event['details'])
+                details=event.get('details'))
         elif state == 'timed_out':
             future._state = futures.FINISHED
             future._exception = exceptions.TimeoutError(


### PR DESCRIPTION
Activity tasks with `raises_on_failure` set to `False` (which is the default with the `with_attributes()` decorator) used to NOT fail the workflow and make it complete. This is a simpleflow abstraction, not a concept brought by SWF. Since https://github.com/botify-labs/simpleflow/commit/a52508cc70b79659ebc23e841c5374d5a353c74b every activity task that raises an exception makes the workflow fail. To be clear I think this breaking change was not anticipated so I consider it a bug.

I reverted the faulty commit and reintroduced part of it. It was mixing minor improvements with a major feature, which is the ability to store multiple exceptions in a wrapper one, so if tasks fail in "cascade" we may identify the dependent task that has caused the problem and why (I think that was the original idea, correct me if I'm wrong).

The plan is to test this branch on a real installation today and see if things get better regarding optional activities (they do on a dummy workflow). We will reintroduce the MultipleException feature later.