### PR TITLE
Use last line in execute.python exception handling

### DIFF
--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -161,16 +161,12 @@ def python(interpreter='python'):
                     )
                 )
                 exclines = err.output.rstrip().rsplit('\n', 2)
-                if len(exclines) == 1:
-                    excline = exclines[0]
-                else:
-                    excline = exclines[1]
+                excline = exclines[-1]
 
                 try:
                     exception = pickle.loads(
                         base64.b64decode(excline.rstrip()))
                 except (TypeError, pickle.UnpicklingError):
-                    excline = exclines[-1]
                     exception = Exception(excline)
                     if ':' in excline:
                         cls, msg = excline.split(':', 1)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -179,3 +179,21 @@ def test_function_as_program_raises_module_exception():
         assert False
 
     assert isinstance(err, TimeoutError)
+
+
+@execute.python()
+def warn():
+    import warnings
+    warnings.warn("The _posixsubprocess module is not being used. "
+                  "Child process reliability may suffer if your "
+                  "program uses threads.", RuntimeWarning)
+    raise StandardError('Fake Standard Error')
+
+
+def test_function_with_warning():
+    try:
+        warn()
+    except StandardError:
+        pass
+    else:
+        assert False


### PR DESCRIPTION
`execute.python` used to take the first or second output line. This should
be the last one, always (I think)