### PR TITLE
workflow.list: don't choke on unnamed taks

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -244,7 +244,7 @@ def list_workflows(ctx, domain, status, started_since):
 @cli.command('workflow.filter', help='Filter workflow executions.')
 @click.option('--status', '-s', default='open', show_default=True, type=click.Choice(['open', 'closed']),
               help='Open/Closed')
-@click.option('--tag', default=None, help='Tag (multiple option).'  # , multiple=True
+@click.option('--tag', default=None, help='Tag.'
               )
 @click.option('--workflow-id', default=None, help='Workflow ID.')
 @click.option('--workflow-type-name', default=None, help='Workflow Name.')

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -187,7 +187,7 @@ def status(workflow_execution, nb_tasks=None):
 
     header = 'Tasks', 'Last State', 'Last State Time', 'Scheduled Time'
     rows = [
-        (task['name'],) + get_timestamps(task) for task in
+        (task.get('name', '(no name)'),) + get_timestamps(task) for task in
         history._tasks[::-1]
         ]
     if nb_tasks:


### PR DESCRIPTION
Tasks can have no name (say, if the events queue overflowed). Don't fail
in this case.

Also remove a bogus help description.
