### PR TITLE
Feature: child workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
-.coverage
+.coverage*
 nosetests.xml
 
 # Translations

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -40,8 +40,7 @@ class Delay(object):
 class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
-    task_list = 'test'
-    execution_timeout = 60 * 5
+    task_list = 'example'
 
     def run(self, x, t=30):
         execution = self.get_execution_context()

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -41,6 +41,7 @@ class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
     task_list = 'example'
+    execution_timeout = 60 * 5
 
     def run(self, x, t=30):
         execution = self.get_execution_context()

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -40,7 +40,7 @@ class Delay(object):
 class BasicWorkflow(Workflow):
     name = 'basic'
     version = 'example'
-    task_list = 'example'
+    task_list = 'test'
     execution_timeout = 60 * 5
 
     def run(self, x, t=30):

--- a/examples/child_workflow.py
+++ b/examples/child_workflow.py
@@ -1,0 +1,39 @@
+from simpleflow import (
+    activity,
+    futures,
+    Workflow,
+)
+
+# This file demonstrates ability to handle Child Workflows with simpleflow.
+# Basically it launches a ParentWorkflow that triggers a ChildWorkflow in
+# the middle of the process.
+
+@activity.with_attributes(task_list='quickstart', version='example')
+def loudly_increment(x, whoami):
+    result = x + 1
+    print "I am {} and I'll increment x={} : result={}".format(whoami, x, result)
+    return result
+
+
+class ChildWorkflow(Workflow):
+    name = 'basic'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self, x):
+        y = self.submit(loudly_increment, x, "CHILD")
+        z = self.submit(loudly_increment, y, "CHILD")
+        return z.result
+
+
+class ParentWorkflow(Workflow):
+    name = 'basic'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self, x):
+        y = self.submit(loudly_increment, x, "PARENT")
+        z = self.submit(ChildWorkflow, y)
+        t = self.submit(loudly_increment, z, "PARENT")
+        print "Final result should be: {} + 4 = {}".format(x, t.result)
+        return t.result

--- a/examples/child_workflow.py
+++ b/examples/child_workflow.py
@@ -15,12 +15,9 @@ from simpleflow import (
 
 # Notes:
 #
-# * handling workflow ids is awkward. Two ways currently exist as shown here:
-#    1. a `get_workflow_id` class method returning the full workflow id
-#    2. a `workflow_name` argument to submit (not passed to the workflow), used
-#       as "workflow-{workflow_name}-N"
+# * defining workflow ids is automatic for idempotent workflows and handled to the class otherwise:
+#    a `get_workflow_id(*args, **kwargs)` class method returning the full workflow id
 #
-# * the N above is too fragile to be useful, unlike for activity tasks
 
 
 @activity.with_attributes(task_list='quickstart', version='example')
@@ -37,7 +34,11 @@ class ChildWorkflow(Workflow):
     task_list = 'example'
     execution_timeout = 60 * 5
 
-    def run(self, x, name="CHILD"):
+    @classmethod
+    def get_workflow_id(cls, *args, **kwargs):
+        return kwargs.get('workflow_name', None)
+
+    def run(self, x, name="CHILD", **kwargs):
         y = self.submit(loudly_increment, x, name)
         z = self.submit(loudly_increment, y, name)
         return z.result

--- a/examples/child_workflow.py
+++ b/examples/child_workflow.py
@@ -1,8 +1,9 @@
+from __future__ import print_function
 from simpleflow import (
     activity,
-    futures,
     Workflow,
 )
+
 
 # This file demonstrates ability to handle Child Workflows with simpleflow.
 # Basically it launches a ParentWorkflow that triggers a ChildWorkflow in
@@ -10,15 +11,17 @@ from simpleflow import (
 
 @activity.with_attributes(task_list='quickstart', version='example')
 def loudly_increment(x, whoami):
+    # WARNING? PARENT executed on example, CHILD on quickstart
     result = x + 1
-    print "I am {} and I'll increment x={} : result={}".format(whoami, x, result)
+    print("I am {} and I'll increment x={} : result={}".format(whoami, x, result))
     return result
 
 
 class ChildWorkflow(Workflow):
-    name = 'basic'
+    name = 'basic_child'
     version = 'example'
     task_list = 'example'
+    execution_timeout = 60 * 5
 
     def run(self, x):
         y = self.submit(loudly_increment, x, "CHILD")
@@ -27,7 +30,7 @@ class ChildWorkflow(Workflow):
 
 
 class ParentWorkflow(Workflow):
-    name = 'basic'
+    name = 'basic_parent'
     version = 'example'
     task_list = 'example'
 
@@ -35,5 +38,5 @@ class ParentWorkflow(Workflow):
         y = self.submit(loudly_increment, x, "PARENT")
         z = self.submit(ChildWorkflow, y)
         t = self.submit(loudly_increment, z, "PARENT")
-        print "Final result should be: {} + 4 = {}".format(x, t.result)
+        print("Final result should be: {} + 4 = {}".format(x, t.result))
         return t.result

--- a/examples/child_workflow.py
+++ b/examples/child_workflow.py
@@ -18,6 +18,7 @@ from simpleflow import (
 # * defining workflow ids is automatic for idempotent workflows and handled to the class otherwise:
 #    a `get_workflow_id(*args, **kwargs)` class method returning the full workflow id
 #
+# * similarly, the WF can define a `get_tag_list(*args, **kwargs)` class method
 
 
 @activity.with_attributes(task_list='quickstart', version='example')
@@ -38,6 +39,10 @@ class ChildWorkflow(Workflow):
     def get_workflow_id(cls, *args, **kwargs):
         return kwargs.get('workflow_name', None)
 
+    @classmethod
+    def get_tag_list(cls, *args, **kwargs):
+        return kwargs.get('tag_list', None)
+
     def run(self, x, name="CHILD", **kwargs):
         y = self.submit(loudly_increment, x, name)
         z = self.submit(loudly_increment, y, name)
@@ -53,7 +58,7 @@ class IdempotentChildWorkflow(Workflow):
 
     def run(self, x):
         # A different workflow name or id is necessary
-        y = self.submit(ChildWorkflow, x, name='SUB-CHILD', workflow_name='sub_child')
+        y = self.submit(ChildWorkflow, x, name='SUB-CHILD', workflow_name='sub_child', tag_list=['abc', 'def=3'])
         return y.result + randrange(1000000)
 
 

--- a/examples/child_workflow.py
+++ b/examples/child_workflow.py
@@ -23,7 +23,6 @@ from simpleflow import (
 
 @activity.with_attributes(task_list='quickstart', version='example')
 def loudly_increment(x, whoami):
-    # WARNING? PARENT executed on example, CHILD on quickstart
     result = x + 1
     print("I am {} and I'll increment x={} : result={}".format(whoami, x, result))
     return result

--- a/examples/complex.py
+++ b/examples/complex.py
@@ -1,0 +1,25 @@
+import time
+
+from simpleflow import (
+    activity,
+    Workflow,
+    futures,
+)
+
+from . import basic
+
+
+@activity.with_attributes(task_list='quickstart', version='example')
+def add(a, b):
+    return a + b
+
+
+class ComplexWorkflow(Workflow):
+    name = 'complex'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self, x, t=30):
+        y = self.submit(basic.BasicWorkflow, x, t)
+        z = self.submit(basic.BasicWorkflow, x + 1, t)
+        return self.submit(add, y, z).result

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -380,7 +380,9 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
               help='Heartbeat interval in seconds (0 to disable heartbeating).')
 @click.option('--nb-processes', '-N', type=int)
 @click.option('--log-level', '-l')
-@click.option('--task-list')
+@click.option('--task-list',
+              required=True,
+              )
 @click.option('--domain', '-d',
               envvar='SWF_DOMAIN',
               required=True,

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -58,3 +58,12 @@ class TimeoutError(Exception):
         return '{}({})'.format(
             self.__class__.__name__,
             self.timeout_type)
+
+
+class TaskCanceled(Exception):
+    def __init__(self, details=None):
+        self.details = details
+
+
+class TaskTerminated(Exception):
+    pass

--- a/simpleflow/futures.py
+++ b/simpleflow/futures.py
@@ -137,3 +137,15 @@ class Future(object):
             CANCELLED,
             FINISHED
         ]
+
+    # Internal methods
+    def set_running(self):
+        self._state = RUNNING
+
+    def set_exception(self, exception):
+        self._state = FINISHED
+        self._exception = exception
+
+    def set_finished(self, result):
+        self._state = FINISHED
+        self._result = result

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -197,11 +197,8 @@ class History(object):
                 'initiated_event_id': event.id,
                 'raw_input': event.raw.get('input'),
                 'child_policy': event.child_policy,
-                'control': event.control,
-                'tag_list': event.tag_list,
-                'task_list': event.task_list,
+                'initiated_event_timestamp': event.timestamp,
             }
-            workflow['initiated_event_timestamp'] = event.timestamp
             if event.workflow_id not in self._child_workflows:
                 self._child_workflows[event.workflow_id] = workflow
                 self._tasks.append(workflow)

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -156,13 +156,27 @@ class History(object):
     def parse_child_workflow_event(self, events, event):
         """Aggregate all the attributes of a workflow in a single entry.
 
-        Missing event state are:
+        See http://docs.aws.amazon.com/amazonswf/latest/apireference/API_HistoryEvent.html
 
-            - start_failed
-            - failed
-            - timed_out
-            - canceled
-            - terminated
+        - StartChildWorkflowExecutionInitiated: A request was made to start a
+          child workflow execution.
+        - StartChildWorkflowExecutionFailed: Failed to process
+          StartChildWorkflowExecution decision. This happens when the decision
+          is not configured properly, for example the workflow type specified
+          is not registered.
+        - ChildWorkflowExecutionStarted: A child workflow execution was
+          successfully started.
+        - ChildWorkflowExecutionCompleted: A child workflow execution, started
+          by this workflow execution, completed successfully and was closed.
+        - ChildWorkflowExecutionFailed: A child workflow execution, started by
+          this workflow execution, failed to complete successfully and was
+          closed.
+        - ChildWorkflowExecutionTimedOut: A child workflow execution, started
+          by this workflow execution, timed out and was closed.
+        - ChildWorkflowExecutionCanceled: A child workflow execution, started
+          by this workflow execution, was canceled and closed.
+        - ChildWorkflowExecutionTerminated: A child workflow execution, started
+          by this workflow execution, was terminated.
 
         :param events:
         :type events: list[swf.models.event.Event]
@@ -193,6 +207,20 @@ class History(object):
                 self._tasks.append(workflow)
             else:
                 self._child_workflows[event.workflow_id].update(workflow)
+        elif event.state == 'start_failed':
+            workflow = {
+                'type': 'child_workflow',
+                'state': event.state,
+                'cause': event.cause,
+                'workflow_type': event.workflow_type.copy(),
+                'start_failed_timestamp': event.timestamp,
+            }
+            if event.workflow_id not in self._child_workflows:
+                self._child_workflows[event.workflow_id] = workflow
+                self._tasks.append(workflow)
+            else:
+                self._child_workflows[event.workflow_id].update(workflow)
+
         elif event.state == 'started':
             workflow = get_workflow(event)
             workflow['state'] = event.state
@@ -206,6 +234,39 @@ class History(object):
             workflow['result'] = event.result
             workflow['completed_id'] = event.id
             workflow['completed_timestamp'] = event.timestamp
+        elif event.state == 'failed':
+            workflow = get_workflow(event)
+            workflow['state'] = event.state
+            workflow['reason'] = event.reason
+            workflow['details'] = event.details
+            workflow['failed_id'] = event.id
+            workflow['failed_timestamp'] = event.timestamp
+        elif event.state == 'timed_out':
+            workflow = get_workflow(event)
+            workflow['state'] = event.state
+            workflow['timeout_type'] = event.timeout_type
+            workflow['timeout_value'] = getattr(
+                events[workflow['initiated_event_id'] - 1],
+                '{}_timeout'.format(event.timeout_type.lower()),
+                None,
+            )
+            workflow['timed_out_id'] = event.id
+            workflow['timed_out_timestamp'] = event.timestamp
+            if 'retry' not in workflow:
+                workflow['retry'] = 0
+            else:
+                workflow['retry'] += 1
+        elif event.state == 'canceled':
+            workflow = get_workflow(event)
+            workflow['state'] = event.state
+            workflow['details'] = getattr(event, 'details', None)
+            workflow['canceled_id'] = event.id
+            workflow['canceled_timestamp'] = event.timestamp
+        elif event.state == 'terminated':
+            workflow = get_workflow(event)
+            workflow['state'] = event.state
+            workflow['terminated_id'] = event.id
+            workflow['terminated_timestamp'] = event.timestamp
 
     def parse(self):
         """

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -27,7 +27,7 @@ class Executor(executor.Executor):
         if isinstance(func, Activity):
             task = ActivityTask(func, *args, **kwargs)
         elif issubclass(func, Workflow):
-            task = WorkflowTask(func, *args, __executor=self, **kwargs)
+            task = WorkflowTask(self, func, *args, **kwargs)
         else:
             raise Exception('Unexpected type {} for func'.format(type(func)))
 

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -28,6 +28,8 @@ class Executor(executor.Executor):
             task = ActivityTask(func, *args, **kwargs)
         elif issubclass(func, Workflow):
             task = WorkflowTask(func, *args, __executor=self, **kwargs)
+        else:
+            raise Exception('Unexpected type {} for func'.format(type(func)))
 
         try:
             future._result = task.execute()

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -29,7 +29,8 @@ class Executor(executor.Executor):
         elif issubclass(func, Workflow):
             task = WorkflowTask(self, func, *args, **kwargs)
         else:
-            raise Exception('Unexpected type {} for func'.format(type(func)))
+            raise TypeError('invalid type {} for {}'.format(
+                type(func), func))
 
         try:
             future._result = task.execute()

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -560,7 +560,7 @@ class Executor(executor.Executor):
             if isinstance(func, Activity):
                 a_task = ActivityTask(func, *args, **kwargs)
             elif issubclass_(func, Workflow):
-                a_task = WorkflowTask(func, *args, __executor=self, **kwargs)
+                a_task = WorkflowTask(self, func, *args, **kwargs)
             else:
                 raise TypeError('invalid type {} for {}'.format(
                     type(func), func))

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -128,7 +128,7 @@ class TaskRegistry(dict):
     def add(self, a_task):
         """
         ID's are assigned sequentially by incrementing an integer. They start
-        from 0.
+        from 1.
 
         :type a_task: ActivityTask | WorkflowTask
         :returns:
@@ -211,7 +211,7 @@ class Executor(executor.Executor):
             arguments = json_dumps({"args": args, "kwargs": kwargs}, sort_keys=True)
             suffix = hashlib.md5(arguments.encode('utf-8')).hexdigest()
 
-        task_id = '{name}-{idx}'.format(name=a_task.name, idx=suffix)
+        task_id = '{name}-{suffix}'.format(name=a_task.name, suffix=suffix)
         return task_id
 
     def _get_future_from_activity_event(self, event):
@@ -422,7 +422,8 @@ class Executor(executor.Executor):
         """
         future = self._get_future_from_child_workflow_event(event)
 
-        if not future:  # Happens, not sure what it means ; TODO: clarify that
+        if not future:  # Happens, not sure what it means; TODO: clarify that
+            logger.warning('FIXME: No future! event={}'.format(event))
             return None
 
         if future.state == "FINISHED" and future.exception:
@@ -435,7 +436,7 @@ class Executor(executor.Executor):
         Let a task schedule itself.
         If too many decisions are in flight, add a timer decision and raise ExecutionBlocked.
         :param a_task:
-        :type a_task: ActivityTask
+        :type a_task: ActivityTask | WorkflowTask
         :param task_list:
         :type task_list: Optional[str]
         :return:

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -422,6 +422,9 @@ class Executor(executor.Executor):
         """
         future = self._get_future_from_child_workflow_event(event)
 
+        if not future:  # Happens, not sure what it means ; TODO: clarify that
+            return None
+
         if future.state == "FINISHED" and future.exception:
             raise future.exception
 
@@ -557,7 +560,7 @@ class Executor(executor.Executor):
             if isinstance(func, Activity):
                 a_task = ActivityTask(func, *args, **kwargs)
             elif issubclass_(func, Workflow):
-                a_task = WorkflowTask(func, *args, **kwargs)
+                a_task = WorkflowTask(func, *args, __executor=self, **kwargs)
             else:
                 raise TypeError('invalid type {} for {}'.format(
                     type(func), func))

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -501,7 +501,9 @@ class Executor(executor.Executor):
         :rtype: futures.Future
         :raise: exceptions.ExecutionBlocked if open activities limit reached
         """
-        a_task.id = self._make_task_id(a_task, *args, **kwargs)
+
+        if not a_task.id:  # Could be set by a subclass
+            a_task.id = self._make_task_id(a_task, *args, **kwargs)
         event = self.find_event(a_task, self._history)
         logger.debug('executor: resume {}, event={}'.format(a_task, event))
         future = None

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -63,9 +63,7 @@ def run_fake_activity_task(domain, task_list, result):
 @retry.with_delay(nb_times=3,
                   delay=retry.exponential,
                   on_exceptions=KeyError)
-def run_fake_child_workflow_task(domain, task_list, workflow_type_name,
-                                 workflow_type_version, workflow_id, input=None, result=None,
-                                 child_policy=None, control=None, tag_list=None):
+def run_fake_child_workflow_task(domain, task_list, result=None):
     conn = ConnectedSWFObject().connection
     resp = conn.poll_for_decision_task(
         domain,
@@ -101,17 +99,9 @@ def run_fake_task_worker(domain, task_list, former_event):
             args=(
                 domain,
                 task_list,
-                former_event['result'],
-                former_event['name'],  # workflow_type_name
-                former_event['version'],  # workflow_type_version
-                former_event['id'],  # workflow_id
             ),
             kwargs={
-                'input': former_event['raw_input'],
                 'result': former_event['result'],
-                'child_policy': former_event['child_policy'],
-                'control': former_event['control'],
-                'tag_list': former_event['tag_list'],
             },
         )
     else:

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -24,12 +24,36 @@ class Decider(Supervisor):
 
     @classmethod
     def make(cls, workflows, domain, task_list, nb_children=None):
+        """
+        Factory method.
+
+        :param workflows:
+        :type workflows: list[str]
+        :param domain:
+        :type domain: str
+        :param task_list:
+        :type task_list: str
+        :param nb_children:
+        :type nb_children: int
+        :return:
+        :rtype: Decider
+        """
         poller = DeciderPoller.make(workflows, domain, task_list)
         return Decider(poller, nb_children=nb_children)
 
 
 class DeciderPoller(Poller, swf.actors.Decider):
-    def __init__(self, executors, domain, task_list, nb_retries=3,
+    """
+    Decider poller.
+
+    :ivar _workflow_name: concatenated workflows names.
+    :type _workflow_name: str
+    :ivar _workflow_executors: executors dict: workflow name -> executor
+    :type _workflow_executors: dict[str, simpleflow.swf.executor.Executor]
+    :ivar nb_retries: # of retries allowed
+    :type nb_retries: int
+    """
+    def __init__(self, workflow_executors, domain, task_list, nb_retries=3,
                  *args, **kwargs):
         """
         The decider is an actor that reads the full history of the workflow
@@ -47,33 +71,34 @@ class DeciderPoller(Poller, swf.actors.Decider):
         behind this is to limit operational burden by having a single service
         handling multiple workflows.
 
-        :param executors: executors handling workflow executions.
-        :type  executors: list[simpleflow.swf.executor.Executor]
+        :param workflow_executors: executors handling workflow executions.
+        :type  workflow_executors: list[simpleflow.swf.executor.Executor]
 
         """
         self._workflow_name = '{}'.format(','.join(
             [
-                ex.workflow.name for ex in executors
+                ex.workflow.name for ex in workflow_executors
                 ]))
 
         # Maps a workflow's name to its definition.
         # Used to dispatch a decision task to the corresponding workflow.
-        self._workflows = {
-            executor.workflow.name: executor for executor in executors
+        self._workflow_executors = {
+            executor.workflow.name: executor for executor in workflow_executors
             }
 
         if not task_list:
-            task_list = executors[0].workflow.task_list
+            task_list = workflow_executors[0].workflow.task_list
 
         # All executors must have the same domain and task list.
-        for ex in executors[1:]:
+        for ex in workflow_executors:
             if ex.domain.name != domain.name:
                 raise ValueError(
                     'all workflows must be in the same domain "{}"'.format(
                         domain.name))
             if ex.workflow.task_list != task_list:
-                raise ValueError(
-                    'all workflows must have the same task list "{}"'.format(
+                # FIXME really needed?
+                logger.warning(
+                    'all workflows should have the same task list "{}"'.format(
                         task_list))
 
         self.nb_retries = nb_retries
@@ -85,20 +110,8 @@ class DeciderPoller(Poller, swf.actors.Decider):
             cls=self.__class__.__name__,
             domain=self.domain.name,
             task_list=self.task_list,
-            workflows=','.join(self._workflows),
+            workflows=','.join(self._workflow_executors),
         )
-
-    @classmethod
-    def make(cls, workflows, domain, task_list):
-        """Factory to build a decider."""
-        from . import helpers
-
-        executors = [
-            helpers.load_workflow(domain, workflow, task_list) for
-            workflow in workflows
-        ]
-        domain = swf.models.Domain(domain)
-        return cls(executors, domain, task_list)
 
     @property
     def name(self):
@@ -154,16 +167,26 @@ class DeciderPoller(Poller, swf.actors.Decider):
         :returns:
         :rtype: list[swf.models.decision.base.Decision]
         """
-        worker = DeciderWorker(self.domain, self._workflows)
+        worker = DeciderWorker(self.domain, self._workflow_executors)
         decisions = worker.decide(decision_response)
         return decisions
 
 
 class DeciderWorker(object):
-    def __init__(self, domain, workflows):
+    """
+    Decider worker.
+    :ivar _domain: SWF domain.
+    :type _domain: swf.models.Domain
+    :ivar _workflow_name: current workflow name. For debugging and such?
+    :type _workflow_name: str
+    :ivar _workflow_executors: executors.
+    :type _workflow_executors: dict[str, simpleflow.swf.executor.Executor]
+    """
+
+    def __init__(self, domain, workflow_executors):
         self._domain = domain
         self._workflow_name = None
-        self._workflows = workflows
+        self._workflow_executors = workflow_executors
 
     def decide(self, decision_response):
         """
@@ -177,14 +200,14 @@ class DeciderWorker(object):
         """
         history = decision_response.history
         workflow_name = history[0].workflow_type['name']
-        workflow_executor = self._workflows.get(workflow_name)
+        workflow_executor = self._workflow_executors.get(workflow_name)
         if not workflow_executor:
             from . import helpers
-            workflow_executor = helpers.load_workflow(
+            workflow_executor = helpers.load_workflow_executor(
                 self._domain,
                 workflow_name,
             )
-            self._workflows[workflow_name] = workflow_executor
+            self._workflow_executors[workflow_name] = workflow_executor
         self._workflow_name = workflow_name
         try:
             decisions = workflow_executor.replay(decision_response)

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -9,7 +9,6 @@ import swf.models.decision
 
 from simpleflow.process import Supervisor, with_state
 from simpleflow.swf.process import Poller
-from . import helpers
 
 
 logger = logging.getLogger(__name__)
@@ -92,6 +91,8 @@ class DeciderPoller(Poller, swf.actors.Decider):
     @classmethod
     def make(cls, workflows, domain, task_list):
         """Factory to build a decider."""
+        from . import helpers
+
         executors = [
             helpers.load_workflow(domain, workflow, task_list) for
             workflow in workflows
@@ -178,6 +179,7 @@ class DeciderWorker(object):
         workflow_name = history[0].workflow_type['name']
         workflow_executor = self._workflows.get(workflow_name)
         if not workflow_executor:
+            from . import helpers
             workflow_executor = helpers.load_workflow(
                 self._domain,
                 workflow_name,
@@ -192,7 +194,7 @@ class DeciderWorker(object):
             import traceback
             details = traceback.format_exc()
             message = "workflow decision failed: {}".format(err)
-            logger.error(message)
+            logger.exception(message)
             decision = swf.models.decision.WorkflowExecutionDecision()
             decision.fail(reason=swf.format.reason(message), details=swf.format.details(details))
             decisions = [decision]

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -22,25 +22,6 @@ class Decider(Supervisor):
             nb_children=nb_children,
         )
 
-    @classmethod
-    def make(cls, workflows, domain, task_list, nb_children=None):
-        """
-        Factory method.
-
-        :param workflows:
-        :type workflows: list[str]
-        :param domain:
-        :type domain: str
-        :param task_list:
-        :type task_list: str
-        :param nb_children:
-        :type nb_children: int
-        :return:
-        :rtype: Decider
-        """
-        poller = DeciderPoller.make(workflows, domain, task_list)
-        return Decider(poller, nb_children=nb_children)
-
 
 class DeciderPoller(Poller, swf.actors.Decider):
     """

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 class Decider(Supervisor):
+    """
+    Decider.
+
+    :ivar _poller: decider poller.
+    :type _poller: DeciderPoller
+    """
     def __init__(self, poller, nb_children=None):
         self._poller = poller
         super(Decider, self).__init__(
@@ -100,6 +106,7 @@ class DeciderPoller(Poller, swf.actors.Decider):
         The main purpose of this property is to find what workflow a decider
         handles.
 
+        :rtype: str
         """
         if self._workflow_name:
             suffix = '(workflow={})'.format(self._workflow_name)
@@ -117,14 +124,12 @@ class DeciderPoller(Poller, swf.actors.Decider):
 
     def process(self, decision_response):
         """
-        Takes a PollForDecisionTask response object and tries to complete the
+        Take a PollForDecisionTask response object and try to complete the
         decision task, by calling self._complete() with the response token and
         a set of decisions.
 
-        :param decision_response: an object wrapping the PollForDecisionTask response
+        :param decision_response: an object wrapping the PollForDecisionTask response.
         :type  decision_response: swf.responses.Response
-
-        :returns: None
         """
         logger.info('taking decision for workflow {}'.format(
             self._workflow_name))
@@ -142,10 +147,10 @@ class DeciderPoller(Poller, swf.actors.Decider):
         Delegate the decision to the decider worker (which itself delegates to
         the executor).
 
-        :param decision_response: an object wrapping the PollForDecisionTask response
+        :param decision_response: an object wrapping the PollForDecisionTask response.
         :type  decision_response: swf.responses.Response
 
-        :returns:
+        :return: the decisions.
         :rtype: list[swf.models.decision.base.Decision]
         """
         worker = DeciderWorker(self.domain, self._workflow_executors)
@@ -171,18 +176,19 @@ class DeciderWorker(object):
 
     def decide(self, decision_response):
         """
-        Delegate the decision to the executor.
+        Delegate the decision to the executor, loading it if needed.
 
-        :param decision_response: an object wrapping the PollForDecisionTask response
+        :param decision_response: an object wrapping the PollForDecisionTask response.
         :type  decision_response: swf.responses.Response
 
-        :returns: the decisions
+        :returns: the decisions.
         :rtype: list[swf.models.decision.base.Decision]
         """
         history = decision_response.history
         workflow_name = history[0].workflow_type['name']
         workflow_executor = self._workflow_executors.get(workflow_name)
         if not workflow_executor:
+            # FIXME is this possible?
             from . import helpers
             workflow_executor = helpers.load_workflow_executor(
                 self._domain,
@@ -192,7 +198,7 @@ class DeciderWorker(object):
         self._workflow_name = workflow_name
         try:
             decisions = workflow_executor.replay(decision_response)
-            if isinstance(decisions, tuple) and len(decisions) == 2:  # (decisions, context)
+            if isinstance(decisions, tuple) and len(decisions) == 2:  # (decisions, obsolete context)
                 decisions = decisions[0]
         except Exception as err:
             import traceback

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -25,7 +25,12 @@ def load_workflow(domain, workflow_name, task_list=None, repair_with=None,
     module = __import__(module_name, fromlist=['*'])
 
     workflow = getattr(module, object_name)
-    return Executor(swf.models.Domain(domain), workflow, task_list,
+
+    # TODO: find the cause of this differentiated behaviour
+    if not isinstance(domain, swf.models.Domain):
+        domain = swf.models.Domain(domain)
+
+    return Executor(domain, workflow, task_list,
                     repair_with=repair_with, force_activities=force_activities)
 
 

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -1,10 +1,7 @@
 import swf.models
 
 from simpleflow.swf.executor import Executor
-from . import (
-    Decider,
-    DeciderPoller,
-)
+from . import Decider, DeciderPoller
 
 
 def load_workflow(domain, workflow_name, task_list=None, repair_with=None,

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -1,7 +1,10 @@
 import swf.models
 
 from simpleflow.swf.executor import Executor
-from . import Decider, DeciderPoller
+from . import (
+    Decider,
+    DeciderPoller,
+)
 
 
 def load_workflow(domain, workflow_name, task_list=None, repair_with=None,

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -7,12 +7,13 @@ from . import (
 )
 
 
-def load_workflow(domain, workflow_name, task_list=None, repair_with=None,
-                  force_activities=None):
+def load_workflow_executor(domain, workflow_name, task_list=None, repair_with=None,
+                           force_activities=None):
     """
-    Load a workflow.
+    Load a workflow executor.
+
     :param domain:
-    :type domain: str
+    :type domain: str | swf.models.Domain
     :param workflow_name:
     :type workflow_name: str
     :param task_list:
@@ -64,10 +65,9 @@ def make_decider_poller(workflows, domain, task_list, repair_with=None,
         raise ValueError("Sorry you can't repair more than 1 workflow at once!")
 
     executors = [
-        load_workflow(domain, workflow, task_list if is_standalone else None,
-                      repair_with=repair_with,
-                      force_activities=force_activities,
-                      )
+        load_workflow_executor(domain, workflow, task_list if is_standalone else None,
+                               repair_with=repair_with,
+                               force_activities=force_activities)
         for workflow in workflows
         ]
     domain = swf.models.Domain(domain)

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -112,7 +112,7 @@ class WorkflowTask(task.WorkflowTask):
             'start',
             workflow_id=self.id,
             workflow_type=model,
-            task_list=workflow.task_list,
+            task_list=task_list or workflow.task_list,
             input=input,
             tag_list=getattr(workflow, 'tag_list', None),
             child_policy=getattr(workflow, 'child_policy', None),

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -8,6 +8,11 @@ class ActivityTask(task.ActivityTask):
     """
     Activity task managed on SWF.
     """
+
+    @property
+    def task_list(self):
+        return self.activity.task_list
+
     def schedule(self, domain, task_list=None, **kwargs):
         """
         Schedule an activity.
@@ -76,12 +81,17 @@ class WorkflowTask(task.WorkflowTask):
     """
 
     def __init__(self, executor, workflow, *args, **kwargs):
-        super(WorkflowTask, self).__init__(executor, workflow, *args, **kwargs)
         self._workflow_name = kwargs.pop('workflow_name', None)
+
+        super(WorkflowTask, self).__init__(executor, workflow, *args, **kwargs)
 
     @property
     def name(self):
         return 'workflow-{}'.format(self._workflow_name or self.workflow.name)
+
+    @property
+    def task_list(self):
+        return getattr(self.workflow, 'task_list', None)
 
     def schedule(self, domain, task_list=None):
         """
@@ -112,10 +122,10 @@ class WorkflowTask(task.WorkflowTask):
             'start',
             workflow_id=self.id,
             workflow_type=model,
-            task_list=task_list or workflow.task_list,
+            task_list=task_list or self.task_list,
             input=input,
             tag_list=getattr(workflow, 'tag_list', None),
             child_policy=getattr(workflow, 'child_policy', None),
-            execution_timeout=str(workflow.execution_timeout))
+            execution_timeout=str(getattr(workflow, 'execution_timeout', None)))
 
         return [decision]

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -9,8 +9,20 @@ class ActivityTask(task.ActivityTask):
     Activity task managed on SWF.
     """
     def schedule(self, domain, task_list=None, **kwargs):
+        """
+        Schedule an activity.
+
+        :param domain:
+        :type domain: swf.models.Domain
+        :param task_list:
+        :type task_list: Optional[str]
+        :param kwargs:
+        :type kwargs: dict
+        :return:
+        :rtype: list[swf.models.decision.Decision]
+        """
         activity = self.activity
-        # Always involve a GET call to the SWF API which introduces useless
+        # FIXME Always involve a GET call to the SWF API which introduces useless
         # latency if the ActivityType already exists.
         model = swf.models.ActivityType(
             domain,
@@ -27,19 +39,19 @@ class ActivityTask(task.ActivityTask):
             task_list = activity.task_list
         task_timeout = kwargs.get(
             'task_timeout',
-            str(activity.task_start_to_close_timeout),
+            activity.task_start_to_close_timeout,
         )
         duration_timeout = kwargs.get(
             'duration_timeout',
-            str(activity.task_schedule_to_close_timeout),
+            activity.task_schedule_to_close_timeout,
         )
         schedule_timeout = kwargs.get(
             'schedule_timeout',
-            str(activity.task_schedule_to_start_timeout),
+            activity.task_schedule_to_start_timeout,
         )
         heartbeat_timeout = kwargs.get(
             'heartbeat_timeout',
-            str(activity.task_heartbeat_timeout),
+            activity.task_heartbeat_timeout,
         )
 
         decision = swf.models.decision.ActivityTaskDecision(
@@ -49,10 +61,10 @@ class ActivityTask(task.ActivityTask):
             control=None,
             task_list=task_list,
             input=input,
-            task_timeout=task_timeout,
-            duration_timeout=duration_timeout,
-            schedule_timeout=schedule_timeout,
-            heartbeat_timeout=heartbeat_timeout,
+            task_timeout=str(task_timeout),
+            duration_timeout=str(duration_timeout),
+            schedule_timeout=str(schedule_timeout),
+            heartbeat_timeout=str(heartbeat_timeout),
         )
 
         return [decision]
@@ -72,8 +84,18 @@ class WorkflowTask(task.WorkflowTask):
         return 'workflow-{}'.format(self._workflow_name or self.workflow.name)
 
     def schedule(self, domain, task_list=None):
+        """
+        Schedule a child workflow.
+
+        :param domain:
+        :type domain: swf.models.Domain
+        :param task_list:
+        :type task_list: Optional[str]
+        :return:
+        :rtype: list[swf.models.decision.Decision]
+        """
         workflow = self.workflow
-        # Always involve a GET call to the SWF API which introduces useless
+        # FIXME Always involve a GET call to the SWF API which introduces useless
         # latency if the WorkflowType already exists.
         model = swf.models.WorkflowType(
             domain,

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -83,8 +83,8 @@ class WorkflowTask(task.WorkflowTask):
             workflow_type=model,
             task_list=workflow.task_list,
             input=input,
-            tag_list=workflow.tag_list,
-            child_policy=workflow.child_policy,
+            tag_list=getattr(workflow, 'tag_list', None),
+            child_policy=getattr(workflow, 'child_policy', None),
             execution_timeout=str(workflow.execution_timeout))
 
         return [decision]

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -62,6 +62,15 @@ class WorkflowTask(task.WorkflowTask):
     """
     WorkflowTask managed on SWF.
     """
+
+    def __init__(self, executor, workflow, *args, **kwargs):
+        super(WorkflowTask, self).__init__(executor, workflow, *args, **kwargs)
+        self._workflow_name = kwargs.pop('workflow_name', None)
+
+    @property
+    def name(self):
+        return 'workflow-{}'.format(self._workflow_name or self.workflow.name)
+
     def schedule(self, domain, task_list=None):
         workflow = self.workflow
         # Always involve a GET call to the SWF API which introduces useless

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -81,6 +81,7 @@ class WorkflowTask(task.WorkflowTask):
     """
 
     def __init__(self, executor, workflow, *args, **kwargs):
+        # TODO: optionally get the tag_list from the input or a workflow method
         self._workflow_name = kwargs.pop('workflow_name', None)
 
         super(WorkflowTask, self).__init__(executor, workflow, *args, **kwargs)

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -80,15 +80,9 @@ class WorkflowTask(task.WorkflowTask):
     WorkflowTask managed on SWF.
     """
 
-    def __init__(self, executor, workflow, *args, **kwargs):
-        # TODO: optionally get the tag_list from the input or a workflow method
-        self._workflow_name = kwargs.pop('workflow_name', None)
-
-        super(WorkflowTask, self).__init__(executor, workflow, *args, **kwargs)
-
     @property
     def name(self):
-        return 'workflow-{}'.format(self._workflow_name or self.workflow.name)
+        return 'workflow-{}'.format(self.workflow.name)
 
     @property
     def task_list(self):

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -113,13 +113,19 @@ class WorkflowTask(task.WorkflowTask):
             'kwargs': self.kwargs,
         }
 
+        get_tag_list = getattr(workflow, 'get_tag_list', None)
+        if get_tag_list:
+            tag_list = get_tag_list(workflow, *self.args, **self.kwargs)
+        else:
+            tag_list = getattr(workflow, 'tag_list', None)
+
         decision = swf.models.decision.ChildWorkflowExecutionDecision(
             'start',
             workflow_id=self.id,
             workflow_type=model,
             task_list=task_list or self.task_list,
             input=input,
-            tag_list=getattr(workflow, 'tag_list', None),
+            tag_list=tag_list,
             child_policy=getattr(workflow, 'child_policy', None),
             execution_timeout=str(getattr(workflow, 'execution_timeout', None)))
 

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -68,7 +68,7 @@ class WorkflowTask(task.WorkflowTask):
         # latency if the WorkflowType already exists.
         model = swf.models.WorkflowType(
             domain,
-            workflow.name,
+            workflow.__module__ + '.' + workflow.__name__,
             version=workflow.version,
         )
 

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -102,7 +102,7 @@ class WorkflowTask(Task):
         if get_workflow_id:
             if self.idempotent:
                 raise Exception('"get_workflow_id" and "idempotent" are mutually exclusive')
-            self.id = str(get_workflow_id(workflow, *self.args, **self.kwargs))
+            self.id = get_workflow_id(workflow, *self.args, **self.kwargs)
         else:
             self.id = None
 

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -85,13 +85,14 @@ class WorkflowTask(Task):
     """
     Child workflow.
 
-    :type workflow: simpleflow.workflow.Workflow
+    :type workflow: type(simpleflow.workflow.Workflow)
     :type idempotent: bool
     :type args: list[Any]
     :type kwargs: dict[Any, Any]
     :type id: str
     """
     def __init__(self, workflow, *args, **kwargs):
+        self.executor = kwargs.pop('__executor')
         self.workflow = workflow
         # TODO: handle idempotency at workflow level
         self.idempotent = False
@@ -106,7 +107,11 @@ class WorkflowTask(Task):
     def __repr__(self):
         return '{}(workflow={}, args={}, kwargs={}, id={})'.format(
             self.__class__.__name__,
-            self.workflow,
+            self.workflow.__module__ + '.' + self.workflow.__name__,
             self.args,
             self.kwargs,
             self.id)
+
+    def execute(self):
+        workflow = self.workflow(self.executor)
+        return workflow.run(*self.args, **self.kwargs)

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -85,14 +85,14 @@ class WorkflowTask(Task):
     """
     Child workflow.
 
+    :type executor: simpleflow.executor.Executor
     :type workflow: type(simpleflow.workflow.Workflow)
-    :type idempotent: bool
     :type args: list[Any]
     :type kwargs: dict[Any, Any]
     :type id: str
     """
-    def __init__(self, workflow, *args, **kwargs):
-        self.executor = kwargs.pop('__executor')
+    def __init__(self, executor, workflow, *args, **kwargs):
+        self.executor = executor
         self.workflow = workflow
         # TODO: handle idempotency at workflow level
         self.idempotent = False

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -94,8 +94,9 @@ class WorkflowTask(Task):
     def __init__(self, executor, workflow, *args, **kwargs):
         self.executor = executor
         self.workflow = workflow
-        # TODO: handle idempotency at workflow level
-        self.idempotent = False
+        # TODO: handle idempotency at workflow level?
+        # (Needed for naming the task, which happens well before workflow instantiation)
+        self.idempotent = getattr(workflow, 'idempotent', False)
         self.args = self.resolve_args(*args)
         self.kwargs = self.resolve_kwargs(**kwargs)
         self.id = None

--- a/simpleflow/utils/retry.py
+++ b/simpleflow/utils/retry.py
@@ -64,7 +64,7 @@ def with_delay(
                 except on_exceptions as error:
                     wait_delay = delay(nb_retries)
                     log_with(
-                        'error "%s": retrying in %.2f seconds',
+                        'error "%r": retrying in %.2f seconds',
                         error,
                         wait_delay,
                     )

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -150,7 +150,7 @@ class Workflow(object):
         :param details:
         :type details: Optional[str]
         """
-        raise NotImplementedError
+        pass
 
     def on_completed(self, history):
         """
@@ -159,7 +159,7 @@ class Workflow(object):
         :param history:
         :type history: simpleflow.history.History
         """
-        raise NotImplementedError
+        pass
 
     def get_execution_context(self):
         """

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -21,10 +21,6 @@ class Workflow(object):
     # These are needed for workflow on SWF
     name = None
     version = None
-    task_list = None
-    tag_list = None
-    child_policy = None
-    execution_timeout = None
 
     def __init__(self, executor):
         self._executor = executor

--- a/swf/actors/core.py
+++ b/swf/actors/core.py
@@ -5,20 +5,20 @@ from swf.models import Domain
 
 
 class Actor(ConnectedSWFObject):
-    """SWF Actor base class
+    """SWF Actor base class.
 
-    Actor is running through a thread in order for it's polling
-    operations not to be blocking. Many actors might be ran through
+    Actor is running through a thread in order for its polling
+    operations not to be blocking. Many actors might be run in
     the same process.
 
     Usage example: implementing an activity worker or a decider
-    using an actor is the typical usage
+    using an actor is the typical usage.
 
-    :param  domain: Domain the Actor should interact with
-    :type   domain: swf.models.Domain
+    :ivar  domain: Domain the Actor should interact with
+    :type  domain: swf.models.Domain
 
-    :param  task_list: task list the Actor should watch for tasks on
-    :type   task_list: string
+    :ivar  task_list: task list the Actor should watch for tasks on
+    :type  task_list: str
     """
     def __init__(self, domain, task_list):
         super(Actor, self).__init__()
@@ -28,22 +28,22 @@ class Actor(ConnectedSWFObject):
 
     def _set_domain(self, domain):
         if not isinstance(domain, Domain):
-            raise TypeError("domain arg should be swf.models.Domain instance")
+            raise TypeError("domain arg must be a swf.models.Domain instance")
         self.domain = domain
 
     def start(self):
-        """Launches the actor
+        """Launch the actor.
 
-        Any class overriding actor's class should set this
-        method to update actor's status to Actor.STATES.RUNNING
+        A class overriding the Actor class should set this
+        method to update the Actor status to Actor.STATES.RUNNING
         """
         raise NotImplementedError
 
     def stop(self):
-        """Stops the actor
+        """Stop the actor.
 
-        Sets actor's status to Actor.STATES.STOPPED, and
-        waits for the last polling operation to end before
+        Set actor's status to Actor.STATES.STOPPED, and
+        wait for the last polling operation to end before
         shutting down.
         """
         raise NotImplementedError

--- a/swf/models/history/builder.py
+++ b/swf/models/history/builder.py
@@ -385,7 +385,7 @@ class History(swf.models.History):
                 'executionStartToCloseTimeout': '432000',
                 'input': json_dumps(input) if input is not None else '{}',
                 'tagList': tag_list,
-                'taskList': task_list,
+                'taskList': {'name': task_list},
                 'taskStartToCloseTimeout': task_start_to_close_timeout,
                 'workflowId': workflow_id,
                 'workflowType': {

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -837,7 +837,7 @@ def test_workflow_with_child_workflow_failed():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -849,7 +849,7 @@ def test_workflow_with_child_workflow_failed():
     ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.fail(reason='FAIL')
 
@@ -864,7 +864,7 @@ def test_workflow_with_child_workflow_timed_out():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -876,7 +876,7 @@ def test_workflow_with_child_workflow_timed_out():
     ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.fail(reason='timed out')
 
@@ -891,7 +891,7 @@ def test_workflow_with_child_workflow_canceled():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -903,7 +903,7 @@ def test_workflow_with_child_workflow_canceled():
     ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.cancel()
 
@@ -918,7 +918,7 @@ def test_workflow_with_child_workflow_terminated():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -930,7 +930,7 @@ def test_workflow_with_child_workflow_terminated():
     ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.terminate()
 
@@ -1580,7 +1580,7 @@ def test_workflow_task_naming():
     workflow = ATestDefinitionParentWorkflow
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={})
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     assert decisions == [
         {
             'decisionType': 'StartChildWorkflowExecution',
@@ -1627,7 +1627,7 @@ def test_workflow_idempotent_task_naming():
     workflow = ATestDefinitionIdempotentParentWorkflow
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={})
-    decisions, _ = executor.replay(Response(history=history))
+    decisions, _ = executor.replay(Response(history=history, execution=None))
     assert decisions == [
         {
             'decisionType': 'StartChildWorkflowExecution',

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -837,7 +837,7 @@ def test_workflow_with_child_workflow_failed():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
      # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -849,7 +849,7 @@ def test_workflow_with_child_workflow_failed():
         ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.fail(reason='FAIL')
 
@@ -864,7 +864,7 @@ def test_workflow_with_child_workflow_timed_out():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
      # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -876,7 +876,7 @@ def test_workflow_with_child_workflow_timed_out():
         ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.fail(reason='timed out')
 
@@ -891,7 +891,7 @@ def test_workflow_with_child_workflow_canceled():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
      # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -903,7 +903,7 @@ def test_workflow_with_child_workflow_canceled():
         ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.cancel()
 
@@ -918,7 +918,7 @@ def test_workflow_with_child_workflow_terminated():
     executor = Executor(DOMAIN, workflow)
     history = builder.History(workflow, input={'args': (1,)})
 
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
      # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
@@ -930,7 +930,7 @@ def test_workflow_with_child_workflow_terminated():
         ))
     # The child workflow fails and the executor should fail the
     # main workflow.
-    decisions, _ = executor.replay(history)
+    decisions, _ = executor.replay(Response(history=history))
     fail_workflow = swf.models.decision.WorkflowExecutionDecision()
     fail_workflow.terminate()
 

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -1512,8 +1512,9 @@ def test_task_naming():
         "activity-tests.data.activities.triple-bdc09455c37471e0ba7397350413a5e6",
         # idempotent task, with arg 2
         "activity-tests.data.activities.triple-12036b25db61ae6cadf7a003ff523029",
-        # idempotent task, with arg 2 too => same task id
-        "activity-tests.data.activities.triple-12036b25db61ae6cadf7a003ff523029",
+        # idempotent, not rescheduled
+        # # idempotent task, with arg 2 too => same task id
+        # "activity-tests.data.activities.triple-12036b25db61ae6cadf7a003ff523029",
         # class-based task, non idempotent
         "activity-tests.data.activities.Tetra-1",
     ]
@@ -1593,7 +1594,7 @@ def test_workflow_task_naming():
                 'input': json_dumps(
                     {
                         "args": [],
-                        "kwargs": {"workflow_name": "child-one"},
+                        "kwargs": {},  # workflow_name removed from the input
                     }
                 )
             }
@@ -1613,7 +1614,7 @@ class ATestDefinitionIdempotentParentWorkflow(ATestWorkflow):
     name = 'test_parent_workflow'
 
     def run(self):
-        future = self.submit(ATestDefinitionIdempotentChildWithIdWorkflow, workflow_name='child-one')
+        future = self.submit(ATestDefinitionIdempotentChildWithIdWorkflow, a=1, workflow_name='child-one')
         print(future.result)
 
 
@@ -1630,7 +1631,7 @@ def test_workflow_idempotent_task_naming():
                 'taskList': {
                     'name': 'test_task_list'
                 },
-                'workflowId': 'workflow-child-one-4ccae08f0a3b53d01d52c5ea05afb731',
+                'workflowId': 'workflow-child-one-adb86b0326491007eae44a0a692bfc53',
                 'taskStartToCloseTimeout': '300',
                 'executionStartToCloseTimeout': '3600',
                 'workflowType': {
@@ -1640,7 +1641,7 @@ def test_workflow_idempotent_task_naming():
                 'input': json_dumps(
                     {
                         "args": [],
-                        "kwargs": {"workflow_name": "child-one"},
+                        "kwargs": {"a": 1},
                     }
                 )
             }

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -44,8 +44,6 @@ class ATestWorkflow(Workflow):
     task_list = 'test_task_list'
     decision_tasks_timeout = '300'
     execution_timeout = '3600'
-    tag_list = None  # FIXME should be optional
-    child_policy = None  # FIXME should be optional
 
 
 def check_task_scheduled_decision(decision, task):
@@ -789,8 +787,8 @@ def test_workflow_with_child_workflow():
     workflow = ATestDefinitionChildWorkflow
     executor = Executor(DOMAIN, workflow)
 
-    # FIXME the original test only contains args, and check both keys are present.
-    # FIXME But their order is unspecified from one execution to the next
+    # FIXME Py3 the original test only contains args, and check both keys are present.
+    # FIXME Py3 But dict order is unspecified from one execution to the next
     input = {'args': (1,), 'kwargs': {}}
     history = builder.History(workflow, input=input)
 

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
+import re
 from builtins import range
 
 import functools
@@ -838,15 +840,15 @@ def test_workflow_with_child_workflow_failed():
     history = builder.History(workflow, input={'args': (1,)})
 
     decisions, _ = executor.replay(Response(history=history))
-     # Let's add the child workflow to the history to simulate its completion.
+    # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
-            workflow,
-            last_state='failed',
-            workflow_id='workflow-test_workflow-1',
-            task_list=ATestWorkflow.task_list,
-            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
-        ))
+        workflow,
+        last_state='failed',
+        workflow_id='workflow-test_workflow-1',
+        task_list=ATestWorkflow.task_list,
+        input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+    ))
     # The child workflow fails and the executor should fail the
     # main workflow.
     decisions, _ = executor.replay(Response(history=history))
@@ -865,15 +867,15 @@ def test_workflow_with_child_workflow_timed_out():
     history = builder.History(workflow, input={'args': (1,)})
 
     decisions, _ = executor.replay(Response(history=history))
-     # Let's add the child workflow to the history to simulate its completion.
+    # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
-            workflow,
-            last_state='timed_out',
-            workflow_id='workflow-test_workflow-1',
-            task_list=ATestWorkflow.task_list,
-            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
-        ))
+        workflow,
+        last_state='timed_out',
+        workflow_id='workflow-test_workflow-1',
+        task_list=ATestWorkflow.task_list,
+        input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+    ))
     # The child workflow fails and the executor should fail the
     # main workflow.
     decisions, _ = executor.replay(Response(history=history))
@@ -883,7 +885,7 @@ def test_workflow_with_child_workflow_timed_out():
     decision = decisions[0]
     assert decision.type == 'FailWorkflowExecution'
     reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
-    assert reason == 'Cannot replay the workflow: TimeoutError()'
+    assert re.match(r'Cannot replay the workflow: TimeoutError\(.*\)', reason)
 
 
 def test_workflow_with_child_workflow_canceled():
@@ -892,15 +894,15 @@ def test_workflow_with_child_workflow_canceled():
     history = builder.History(workflow, input={'args': (1,)})
 
     decisions, _ = executor.replay(Response(history=history))
-     # Let's add the child workflow to the history to simulate its completion.
+    # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
-            workflow,
-            last_state='canceled',
-            workflow_id='workflow-test_workflow-1',
-            task_list=ATestWorkflow.task_list,
-            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
-        ))
+        workflow,
+        last_state='canceled',
+        workflow_id='workflow-test_workflow-1',
+        task_list=ATestWorkflow.task_list,
+        input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+    ))
     # The child workflow fails and the executor should fail the
     # main workflow.
     decisions, _ = executor.replay(Response(history=history))
@@ -910,7 +912,7 @@ def test_workflow_with_child_workflow_canceled():
     decision = decisions[0]
     assert decision.type == 'FailWorkflowExecution'
     reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
-    assert reason == "Cannot replay the workflow: TaskCanceled()"
+    assert re.match(r"Cannot replay the workflow: TaskCanceled\(.*\)", reason)
 
 
 def test_workflow_with_child_workflow_terminated():
@@ -919,15 +921,15 @@ def test_workflow_with_child_workflow_terminated():
     history = builder.History(workflow, input={'args': (1,)})
 
     decisions, _ = executor.replay(Response(history=history))
-     # Let's add the child workflow to the history to simulate its completion.
+    # Let's add the child workflow to the history to simulate its completion.
     (history
         .add_child_workflow(
-            workflow,
-            last_state='terminated',
-            workflow_id='workflow-test_workflow-1',
-            task_list=ATestWorkflow.task_list,
-            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
-        ))
+        workflow,
+        last_state='terminated',
+        workflow_id='workflow-test_workflow-1',
+        task_list=ATestWorkflow.task_list,
+        input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+    ))
     # The child workflow fails and the executor should fail the
     # main workflow.
     decisions, _ = executor.replay(Response(history=history))

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -805,7 +805,7 @@ def test_workflow_with_child_workflow():
             'input': json_dumps(input),
             'workflowType': {
                 'version': 'test_version',
-                'name': 'test_workflow'
+                'name': 'tests.test_dataflow.TestDefinition'
             },
             'taskStartToCloseTimeout': '300'
         },

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -805,7 +805,7 @@ def test_workflow_with_child_workflow():
             'input': json_dumps(input),
             'workflowType': {
                 'version': 'test_version',
-                'name': 'tests.test_dataflow.TestDefinition'
+                'name': 'tests.test_dataflow.ATestDefinition'
             },
             'taskStartToCloseTimeout': '300'
         },

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -1559,6 +1559,10 @@ def test_execution_context():
 class ATestDefinitionChildWithIdWorkflow(ATestWorkflow):
     name = 'test_child_workflow'
 
+    @classmethod
+    def get_workflow_id(cls, *args, **kwargs):
+        return kwargs.get('workflow_name', None)
+
     def run(self, *args, **kwargs):
         return 42
 
@@ -1567,7 +1571,7 @@ class ATestDefinitionParentWorkflow(ATestWorkflow):
     name = 'test_parent_workflow'
 
     def run(self):
-        future = self.submit(ATestDefinitionChildWithIdWorkflow, workflow_name='child-one')
+        future = self.submit(ATestDefinitionChildWithIdWorkflow, workflow_name='workflow-child-one-1')
         print(future.result)
 
 
@@ -1594,7 +1598,7 @@ def test_workflow_task_naming():
                 'input': json_dumps(
                     {
                         "args": [],
-                        "kwargs": {},  # workflow_name removed from the input
+                        "kwargs": {'workflow_name': 'workflow-child-one-1'},
                     }
                 )
             }
@@ -1614,7 +1618,7 @@ class ATestDefinitionIdempotentParentWorkflow(ATestWorkflow):
     name = 'test_parent_workflow'
 
     def run(self):
-        future = self.submit(ATestDefinitionIdempotentChildWithIdWorkflow, a=1, workflow_name='child-one')
+        future = self.submit(ATestDefinitionIdempotentChildWithIdWorkflow, a=1)
         print(future.result)
 
 
@@ -1631,7 +1635,7 @@ def test_workflow_idempotent_task_naming():
                 'taskList': {
                     'name': 'test_task_list'
                 },
-                'workflowId': 'workflow-child-one-adb86b0326491007eae44a0a692bfc53',
+                'workflowId': 'workflow-test_child_workflow-adb86b0326491007eae44a0a692bfc53',
                 'taskStartToCloseTimeout': '300',
                 'executionStartToCloseTimeout': '3600',
                 'workflowType': {

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -832,6 +832,114 @@ def test_workflow_with_child_workflow():
     assert decisions[0] == workflow_completed
 
 
+def test_workflow_with_child_workflow_failed():
+    workflow = ATestDefinitionChildWorkflow
+    executor = Executor(DOMAIN, workflow)
+    history = builder.History(workflow, input={'args': (1,)})
+
+    decisions, _ = executor.replay(history)
+     # Let's add the child workflow to the history to simulate its completion.
+    (history
+        .add_child_workflow(
+            workflow,
+            last_state='failed',
+            workflow_id='workflow-test_workflow-1',
+            task_list=ATestWorkflow.task_list,
+            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+        ))
+    # The child workflow fails and the executor should fail the
+    # main workflow.
+    decisions, _ = executor.replay(history)
+    fail_workflow = swf.models.decision.WorkflowExecutionDecision()
+    fail_workflow.fail(reason='FAIL')
+
+    decision = decisions[0]
+    assert decision.type == 'FailWorkflowExecution'
+    reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
+    assert reason == "Cannot replay the workflow: TaskFailed(('workflow-test_workflow-1', None, None))"
+
+
+def test_workflow_with_child_workflow_timed_out():
+    workflow = ATestDefinitionChildWorkflow
+    executor = Executor(DOMAIN, workflow)
+    history = builder.History(workflow, input={'args': (1,)})
+
+    decisions, _ = executor.replay(history)
+     # Let's add the child workflow to the history to simulate its completion.
+    (history
+        .add_child_workflow(
+            workflow,
+            last_state='timed_out',
+            workflow_id='workflow-test_workflow-1',
+            task_list=ATestWorkflow.task_list,
+            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+        ))
+    # The child workflow fails and the executor should fail the
+    # main workflow.
+    decisions, _ = executor.replay(history)
+    fail_workflow = swf.models.decision.WorkflowExecutionDecision()
+    fail_workflow.fail(reason='timed out')
+
+    decision = decisions[0]
+    assert decision.type == 'FailWorkflowExecution'
+    reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
+    assert reason == 'Cannot replay the workflow: TimeoutError()'
+
+
+def test_workflow_with_child_workflow_canceled():
+    workflow = ATestDefinitionChildWorkflow
+    executor = Executor(DOMAIN, workflow)
+    history = builder.History(workflow, input={'args': (1,)})
+
+    decisions, _ = executor.replay(history)
+     # Let's add the child workflow to the history to simulate its completion.
+    (history
+        .add_child_workflow(
+            workflow,
+            last_state='canceled',
+            workflow_id='workflow-test_workflow-1',
+            task_list=ATestWorkflow.task_list,
+            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+        ))
+    # The child workflow fails and the executor should fail the
+    # main workflow.
+    decisions, _ = executor.replay(history)
+    fail_workflow = swf.models.decision.WorkflowExecutionDecision()
+    fail_workflow.cancel()
+
+    decision = decisions[0]
+    assert decision.type == 'FailWorkflowExecution'
+    reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
+    assert reason == "Cannot replay the workflow: TaskCanceled()"
+
+
+def test_workflow_with_child_workflow_terminated():
+    workflow = ATestDefinitionChildWorkflow
+    executor = Executor(DOMAIN, workflow)
+    history = builder.History(workflow, input={'args': (1,)})
+
+    decisions, _ = executor.replay(history)
+     # Let's add the child workflow to the history to simulate its completion.
+    (history
+        .add_child_workflow(
+            workflow,
+            last_state='terminated',
+            workflow_id='workflow-test_workflow-1',
+            task_list=ATestWorkflow.task_list,
+            input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
+        ))
+    # The child workflow fails and the executor should fail the
+    # main workflow.
+    decisions, _ = executor.replay(history)
+    fail_workflow = swf.models.decision.WorkflowExecutionDecision()
+    fail_workflow.terminate()
+
+    decision = decisions[0]
+    assert decision.type == 'FailWorkflowExecution'
+    reason = decision['failWorkflowExecutionDecisionAttributes']['reason']
+    assert reason == "Cannot replay the workflow: TaskTerminated()"
+
+
 class ATestDefinitionMoreThanMaxDecisions(ATestWorkflow):
     """
     This workflow executes more tasks than the maximum number of decisions a


### PR DESCRIPTION
Alternate version of #50, WIP : it works, but I think I have a day or two of work on that to polish it / add better tests / add missing things.

99% of the code is from @ggreg but I adapted a few things, nothing serious. A few important notes:
- there's a major change I didn't understand in Greg's first attempt: workflow will now follow the same path as activities and be named via full python paths (path.to.module.Class) ; does anybody think it will be a problem? It allows to re-resolve an other workflow internally more easily
- I had to pass the "executor" to the WorkflowTask object, I'm not very happy with that, if somebody has a better idea... Maybe it's not even so useful, but workflow have to be instantiated with as of today...
- I did NOT include the task list override feature that Greg had included in #50 ; hence task lists won't be overridden on the child workflow, and activities will follow their DEFAULT task list, not the one of the parent workflow / given via the command line ; not a problem a priori for us, but YMMV

Any remark/review welcome!
