### PR TITLE
Simpleflow addition

### DIFF
--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -96,23 +96,23 @@ class Activity(object):
             self.version,
             self.task_list)
 
-    def before_scheduling(*args, *kwargs):
+    def before_scheduling(*args, **kwargs):
         pass
 
-    def after_scheduling(*args, *kwargs):
+    def after_scheduling(*args, **kwargs):
         pass
 
-    def activity_started(*args, *kwargs):
+    def activity_started(*args, **kwargs):
         pass
 
-    def activity_completed(*args, *kwargs):
+    def activity_completed(*args, **kwargs):
         pass
 
-    def activity_canceled(*args, *kwargs):
+    def activity_canceled(*args, **kwargs):
         pass
 
-    def activity_failed(*args, *kwargs):
+    def activity_failed(*args, **kwargs):
         pass
 
-    def activity_timedout(*args, *kwargs):
+    def activity_timedout(*args, **kwargs):
         pass

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -48,7 +48,8 @@ class Activity(object):
                  schedule_to_close_timeout=None,
                  schedule_to_start_timeout=None,
                  heartbeat_timeout=None,
-                 idempotent=None):
+                 idempotent=None,
+                 activity_completed=None):
         self._callable = callable
 
         self._name = name
@@ -61,6 +62,7 @@ class Activity(object):
         self.task_schedule_to_close_timeout = schedule_to_close_timeout
         self.task_schedule_to_start_timeout = schedule_to_start_timeout
         self.task_heartbeat_timeout = heartbeat_timeout
+        self.activity_completed = self.activity_completed if activity_completed is None else activity_completed
 
         self.register()
 
@@ -93,3 +95,24 @@ class Activity(object):
             self.name,
             self.version,
             self.task_list)
+
+    def before_scheduling(*args, *kwargs):
+        pass
+
+    def after_scheduling(*args, *kwargs):
+        pass
+
+    def activity_started(*args, *kwargs):
+        pass
+
+    def activity_completed(*args, *kwargs):
+        pass
+
+    def activity_canceled(*args, *kwargs):
+        pass
+
+    def activity_failed(*args, *kwargs):
+        pass
+
+    def activity_timedout(*args, *kwargs):
+        pass

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -39,7 +39,7 @@ class TaskFailed(Exception):
         super(TaskFailed, self).__init__(name, reason, details)
         self.name = name
         self.reason = reason
-        self.details = None
+        self.details = details
 
     def __repr__(self):
         return '{} ({}, "{}")'.format(

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -60,17 +60,12 @@ class TimeoutError(Exception):
             self.timeout_type)
 
 class TaskCancelled(Exception):
-    def __init__(self, task, exception):
-        """
-        :param exception: raised by a task.
-        :type  exception: TaskFailed.
-
-        """
+    def __init__(self, task, details=None):
         self.task = task
-        self.exception = exception
+        self.details = details
 
     def __repr__(self):
-        return '{}(task={} exception={})'.format(
+        return '{}(task={} details={})'.format(
             self.__class__.__name__,
             self.task,
-            self.exception)
+            self.details)

--- a/simpleflow/exceptions.py
+++ b/simpleflow/exceptions.py
@@ -58,3 +58,19 @@ class TimeoutError(Exception):
         return '{}({})'.format(
             self.__class__.__name__,
             self.timeout_type)
+
+class TaskCancelled(Exception):
+    def __init__(self, task, exception):
+        """
+        :param exception: raised by a task.
+        :type  exception: TaskFailed.
+
+        """
+        self.task = task
+        self.exception = exception
+
+    def __repr__(self):
+        return '{}(task={} exception={})'.format(
+            self.__class__.__name__,
+            self.task,
+            self.exception)

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 
 logger = logging.getLogger(__name__)
 
@@ -116,14 +117,14 @@ class History(object):
                 activity['retry'] = 0
             else:
                 activity['retry'] += 1
-        elif event.state == 'cancelled':
+        elif event.state == 'canceled':
             activity = get_activity(event)
             activity['state'] = event.state
             if hasattr(event, 'details'):
                 activity['details'] = event.details
             activity['cancelled_timestamp'] = event.timestamp
         elif event.state == 'request_cancel_failed':
-            activity = get_activity(event)
+            activity = self._activities[event.activity_id]
             activity['state'] = event.state
             if hasattr(event, 'details'):
                 activity['details'] = event.details

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -86,6 +86,13 @@ class History(object):
                 activity['retry'] = 0
             else:
                 activity['retry'] += 1
+
+            if event.timeout_type == 'HEARTBEAT':
+                if 'retry_heartbeat' not in activity:
+                    activity['retry_heartbeat'] = 0
+                else:
+                    activity['retry_heartbeat'] += 1
+
         elif event.state == 'failed':
             activity = get_activity(event)
             activity['state'] = event.state

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -21,7 +21,7 @@ class History(object):
         """
         List all the activities that are cancellable
         """
-        return filter(lambda x: x.state in ['scheduled', 'started', 'request_cancel_failed'] ,self._activities)
+        return [k for k,v in self._activities.iteritems() if v.state in ['scheduled', 'started', 'request_cancel_failed']]
 
 
     def parse_activity_event(self, events, event):
@@ -174,7 +174,7 @@ class History(object):
                 self.parse_activity_event(events, event)
             elif event.type == 'ChildWorkflowExecution':
                 self.parse_child_workflow_event(events, event)
-            elif event.type == 'WorkflowExecution' and event['state'] == 'cancel_requested':
+            elif event.type == 'WorkflowExecution' and event.state == 'cancel_requested':
                 self._isCancelRequested = True
             else:
                 pass

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -21,7 +21,7 @@ class History(object):
         """
         List all the activities that are cancellable
         """
-        return [k for k,v in self._activities.iteritems() if v.state in ['scheduled', 'started', 'request_cancel_failed']]
+        return [k for k,v in self._activities.iteritems() if v['state'] in ['scheduled', 'started', 'request_cancel_failed']]
 
 
     def parse_activity_event(self, events, event):

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -7,10 +7,22 @@ class History(object):
         self._activities = collections.OrderedDict()
         self._child_workflows = collections.OrderedDict()
         self._tasks = []
+        self._isCancelRequested = False
+
+    @property
+    def is_cancel_requested(self):
+        return self._isCancelRequested
 
     @property
     def events(self):
         return self._history.events
+
+    def list_cancellable_activities(self):
+        """
+        List all the activities that are cancellable
+        """
+        return filter(lambda x: x.state in ['scheduled', 'started', 'request_cancel_failed'] ,self._activities)
+
 
     def parse_activity_event(self, events, event):
         """Aggregate all the attributes of an activity in a single entry.
@@ -162,5 +174,7 @@ class History(object):
                 self.parse_activity_event(events, event)
             elif event.type == 'ChildWorkflowExecution':
                 self.parse_child_workflow_event(events, event)
+            elif event.type == 'WorkflowExecution' and event['state'] == 'cancel_requested':
+                self._isCancelRequested = True
             else:
                 pass

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -333,22 +333,22 @@ class Executor(executor.Executor):
         kwargs = input.get('kwargs', {})
 
         # check if there is a workflow cancellation request
-        if self._history.is_cancel_requested():
+        if self._history.is_cancel_requested:
             # list all the running activities
-            cancellable_activities = self._history.list_cancellable_activities()
+            cancellable_activities_id = self._history.list_cancellable_activities()
 
-            if len(cancellable_activities) == 0:
+            if len(cancellable_activities_id) == 0:
                 # nothing to cancel, completing the workflow as cancelled
                 cancel_decision = swf.models.decision.WorkflowExecutionDecision()
                 cancel_decision.cancel()
                 return [cancel_decision], {}
 
             cancel_activities_decisions = []
-            for activity in cancellable_activities:
+            for activity_id in cancellable_activities_id:
                 # send cancel request to each of them
                 decision = swf.models.decision.ActivityTaskDecision(
                     'request_cancel',
-                    activity_id=activity.id,
+                    activity_id=activity_id,
                 )
 
                 cancel_activities_decisions.append(decision)

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -151,10 +151,11 @@ class DeciderWorker(object):
             if isinstance(decisions, tuple) and len(decisions) == 2:  # (decisions, context)
                 decisions = decisions[0]
         except Exception as err:
+            tb = traceback.format_exc()
             message = "workflow decision failed: {}".format(err)
             logger.error(message)
             decision = swf.models.decision.WorkflowExecutionDecision()
-            decision.fail(reason=swf.format.reason(message))
+            decision.fail(reason=swf.format.reason(message), details=tb)
             decisions = [decision]
 
         return decisions

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -4,6 +4,7 @@ import logging
 
 import swf.actors
 import swf.exceptions
+import traceback
 
 from simpleflow.swf.process.actor import (
     Supervisor,

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -54,6 +54,7 @@ class ActivityTask(task.ActivityTask):
         return [decision]
 
 
+
 class WorkflowTask(task.WorkflowTask):
     def schedule(self, domain, task_list=None):
         workflow = self.workflow

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -37,7 +37,6 @@ class Task(object):
         return {key: get_actual_value(val) for
                 key, val in kwargs.iteritems()}
 
-
 class ActivityTask(Task):
     def __init__(self, activity, *args, **kwargs):
         if not isinstance(activity, Activity):
@@ -67,6 +66,27 @@ class ActivityTask(Task):
         else:
             return method(*self.args, **self.kwargs)
 
+    def before_scheduling(self):
+        self.activity.before_scheduling(*self.args, **self.kwargs)
+
+    def after_scheduling(self):
+        self.activity.after_scheduling(*self.args, **self.kwargs)
+
+    def activity_started(self, event, history):
+        self.activity.activity_started(*self.args, **dict(self.kwargs, event=event, history=history))
+
+    def activity_completed(self, event, history):
+        self.activity.activity_completed(*self.args, **dict(self.kwargs, event=event, history=history))
+
+    def activity_canceled(self, event, history):
+        self.activity.activity_canceled(*self.args, **dict(self.kwargs, event=event, history=history))
+
+    def activity_failed(self, event, history):
+        self.activity.activity_failed(*self.args, **dict(self.kwargs, event=event, history=history))
+
+    def activity_timedout(self, event, history):
+        self.activity.activity_timedout(*self.args, **dict(self.kwargs, event=event, history=history))
+
 
 class WorkflowTask(Task):
     def __init__(self, workflow, *args, **kwargs):
@@ -84,7 +104,13 @@ class WorkflowTask(Task):
     def __repr__(self):
         return '{}(workflow={}, args={}, kwargs={}, id={})'.format(
             self.__class__.__name__,
-            self.activity,
+            self.workflow,
             self.args,
             self.kwargs,
             self.id)
+
+    def before_scheduling(self):
+        self.workflow.before_scheduling(*self.args, **self.kwargs)
+
+    def after_scheduling(self):
+        self.workflow.after_scheduling(*self.args, **self.kwargs)

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -97,8 +97,8 @@ class Workflow(object):
         """
         raise NotImplementedError
 
-    def before_scheduling(*args, *kwargs):
+    def before_scheduling(*args, **kwargs):
         pass
 
-    def after_scheduling(*args, *kwargs):
+    def after_scheduling(*args, **kwargs):
         pass

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -96,3 +96,9 @@ class Workflow(object):
 
         """
         raise NotImplementedError
+
+    def before_scheduling(*args, *kwargs):
+        pass
+
+    def after_scheduling(*args, *kwargs):
+        pass


### PR DESCRIPTION
@glynn-zenefits @usmanghani @zafarabbas @jessecollier 

1. Add several callback functions to allow workflow author to handle events (before/after activity scheduling, on activity timeout, etc). This is not used yet.

2. Make Poller run task body in process. For each task, start a thread to do heartbeating. The heartbeating thread will:
    a. Send heartbeat to SWF.
    b. Send signal to main process if the task is cancelled or timed out. Today we make use of SIGUSR1 to raise TaskCancelled exception to the task process. TODO: Add soft timeout signal to allow task body to catch and handle things gracefully.

3. Make decider able to handle workflow cancellation. When a cancellation of a workflow is issued, the decider will check all the active activities and issue cancellation respectively. Once no active activities are found, the decider closes the workflow.

4. Proper tracing. 

5. Fixed bugs in the original repo.
