### PR TITLE
Canvas: AggregationException

### DIFF
--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -33,16 +33,18 @@ class AggregateException(Exception):
     def append(self, ex):
         self.exceptions.append(ex)
 
-    def handle(self, handler):
+    def handle(self, handler, *args, **kwargs):
         """
         Invoke a user-defined handler on each exception.
         :param handler: Predicate accepting an exception and returning True if it's been handled.
         :type handler: (Exception) -> bool
+        :param args: args for the handler
+        :param kwargs: kwargs for the handler
         :raise: new AggregateException with the unhandled exceptions, if any
         """
         unhandled_exceptions = []
         for ex in self.exceptions:
-            if ex and not handler(ex):
+            if ex and not handler(ex, *args, **kwargs):
                 unhandled_exceptions.append(ex)
         if unhandled_exceptions:
             raise AggregateException(unhandled_exceptions)

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -21,6 +21,43 @@ class FuncGroup(object):
         return inst.submit(executor)
 
 
+class AggregateException(Exception):
+    """
+    Class containing a list of exceptions.
+
+    :type exceptions: list[Exception]
+    """
+    def __init__(self, exceptions):
+        self.exceptions = exceptions
+
+    def append(self, ex):
+        self.exceptions.append(ex)
+
+    def handle(self, handler):
+        """
+        Invoke a handler on each exception.
+        :param handler: Predicate accepting an exception and returning True if it's been handled
+        :type handler:
+        :return: raises a new AggregateException with the unhandled exceptions if any
+        :rtype:
+        """
+        unhandled_exceptions = []
+        for ex in self.exceptions:
+            if ex and not handler(ex):
+                unhandled_exceptions.append(ex)
+        if unhandled_exceptions:
+            raise AggregateException(unhandled_exceptions)
+
+    def __repr__(self):
+        return repr([repr(ex) for ex in self.exceptions])
+
+    def __str__(self):
+        return str([str(ex) for ex in self.exceptions])
+
+    def __eq__(self, other):
+        return self.exceptions == other.exceptions
+
+
 class Group(object):
     """
     List of activities running in parallel.
@@ -72,11 +109,20 @@ class GroupFuture(futures.Future):
 
     def sync_result(self):
         self._result = []
+        exceptions = []
+        have_exceptions = False
         for future in self.futures:
             if future.finished:
                 self._result.append(future.result)
+                exception = future.exception
+                exceptions.append(exception)
+                if exception:
+                    have_exceptions = True
             else:
                 self._result.append(None)
+                exceptions.append(None)
+        if have_exceptions:
+            self._exception = AggregateException(exceptions)
 
     @property
     def count_finished_activities(self):
@@ -112,6 +158,8 @@ class ChainFuture(GroupFuture):
         self.activities = activities
         self.executor = executor
         self._state = futures.PENDING
+        self._result = None
+        self._exception = None
         self.futures = []
 
         previous_result = None

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -130,18 +130,15 @@ class GroupFuture(futures.Future):
     def sync_result(self):
         self._result = []
         exceptions = []
-        have_exceptions = False
         for future in self.futures:
             if future.finished:
                 self._result.append(future.result)
                 exception = future.exception
                 exceptions.append(exception)
-                if exception:
-                    have_exceptions = True
             else:
                 self._result.append(None)
                 exceptions.append(None)
-        if have_exceptions:
+        if any(ex for ex in exceptions):
             self._exception = AggregateException(exceptions)
 
     @property

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -35,11 +35,10 @@ class AggregateException(Exception):
 
     def handle(self, handler):
         """
-        Invoke a handler on each exception.
-        :param handler: Predicate accepting an exception and returning True if it's been handled
-        :type handler:
-        :return: raises a new AggregateException with the unhandled exceptions if any
-        :rtype:
+        Invoke a user-defined handler on each exception.
+        :param handler: Predicate accepting an exception and returning True if it's been handled.
+        :type handler: (Exception) -> bool
+        :raise: new AggregateException with the unhandled exceptions, if any
         """
         unhandled_exceptions = []
         for ex in self.exceptions:

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -48,6 +48,25 @@ class AggregateException(Exception):
         if unhandled_exceptions:
             raise AggregateException(unhandled_exceptions)
 
+    def flatten(self):
+        """
+        Flatten the AggregateException. Return a new instance without inner AggregateException.
+        :return:
+        :rtype: AggregateException
+        """
+        flattened_exceptions = []
+        self._flatten(self, flattened_exceptions)
+        return AggregateException(flattened_exceptions)
+
+    @staticmethod
+    def _flatten(exception, exceptions):
+        if isinstance(exception, AggregateException):
+            for ex in exception.exceptions:
+                if ex:
+                    AggregateException._flatten(ex, exceptions)
+        else:
+            exceptions.append(exception)
+
     def __repr__(self):
         return repr([repr(ex) for ex in self.exceptions])
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -4,8 +4,8 @@ from simpleflow import futures, workflow, exceptions
 from simpleflow.canvas import (
     FuncGroup,
     Group,
-    Chain
-)
+    Chain,
+    AggregateException)
 from simpleflow.local.executor import Executor
 from simpleflow.activity import with_attributes
 from simpleflow.task import ActivityTask
@@ -36,11 +36,17 @@ def running_task():
     return True
 
 
+@with_attributes()
+def zero_division():
+    return 1 / 0
+
+
 class CustomExecutor(Executor):
     """
     This executor returns a running state when
     `running_task` is called
     """
+
     def submit(self, func, *args, **kwargs):
         if func == running_task:
             f = futures.Future()
@@ -71,9 +77,23 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(exceptions.ExecutionBlocked):
             future.result
 
+    def test_exceptions(self):
+        future = Group(
+            ActivityTask(to_string, 1),
+            ActivityTask(to_string, 2)
+        ).submit(executor)
+        self.assertIsNone(future.exception)
+
+        future = Group(
+            ActivityTask(zero_division)
+        ).submit(executor)
+        self.assertTrue(future.finished)
+        self.assertIsInstance(future.exception, AggregateException)
+        self.assertEqual(1, len(future.exception.exceptions))
+        self.assertIsInstance(future.exception.exceptions[0], ZeroDivisionError)
+
 
 class TestChain(unittest.TestCase):
-
     def test(self):
         future = Chain(
             ActivityTask(to_string, "test"),
@@ -100,6 +120,22 @@ class TestChain(unittest.TestCase):
         self.assertTrue(future.finished)
         self.assertEquals(future.result, [3, 8, 17])
 
+    def test_exceptions(self):
+        future = Group(
+            ActivityTask(to_string, 1),
+            ActivityTask(to_string, 2)
+        ).submit(executor)
+        self.assertIsNone(future.exception)
+
+        future = Group(
+            ActivityTask(zero_division)
+        ).submit(executor)
+        self.assertTrue(future.finished)
+        self.assertIsInstance(future.exception, AggregateException)
+        self.assertEqual(1, len(future.exception.exceptions))
+        self.assertIsInstance(future.exception.exceptions[0], ZeroDivisionError)
+
+
 
 class TestFuncGroup(unittest.TestCase):
     def test_previous_value_with_func(self):
@@ -118,7 +154,6 @@ class TestFuncGroup(unittest.TestCase):
 
 
 class TestComplexCanvas(unittest.TestCase):
-
     def test(self):
         complex_canvas = Chain(
             ActivityTask(sum_values, [1, 2]),
@@ -151,3 +186,17 @@ class TestComplexCanvas(unittest.TestCase):
         result = complex_canvas.submit(executor)
         self.assertTrue(result.finished)
         self.assertEquals(len(result.futures), 5)
+
+
+class TestAggregateException(unittest.TestCase):
+    def test_handle_all(self):
+        agg_ex = AggregateException([ZeroDivisionError(), None, MemoryError()])
+        agg_ex.handle(lambda ex: bool(ex))
+
+    def test_handle_not_all(self):
+        memory_error = MemoryError()
+        agg_ex = AggregateException([ZeroDivisionError(), None, memory_error])
+        with self.assertRaises(AggregateException) as new_agg_ex:
+            agg_ex.handle(lambda ex: type(ex) == ZeroDivisionError)
+        self.assertIsInstance(new_agg_ex.exception, AggregateException)
+        self.assertEqual([memory_error], new_agg_ex.exception.exceptions)

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -200,3 +200,27 @@ class TestAggregateException(unittest.TestCase):
             agg_ex.handle(lambda ex: type(ex) == ZeroDivisionError)
         self.assertIsInstance(new_agg_ex.exception, AggregateException)
         self.assertEqual([memory_error], new_agg_ex.exception.exceptions)
+
+    def test_flatten(self):
+        agg_ex = AggregateException(
+            [
+                ZeroDivisionError(), None, MemoryError(),
+                AggregateException(
+                    [
+                        AttributeError(),
+                        AggregateException(
+                            [
+                                ImportError(),
+                            ]
+                        ),
+                        None,
+                    ]
+                ),
+                AggregateException([]),
+            ]
+        )
+        flatten_ex = agg_ex.flatten()
+        self.assertEqual(
+            [ZeroDivisionError, MemoryError, AttributeError, ImportError],
+            [type(ex) for ex in flatten_ex.exceptions]
+        )

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -201,8 +201,12 @@ class TestAggregateException(unittest.TestCase):
     def test_handle_not_all(self):
         memory_error = MemoryError()
         agg_ex = AggregateException([ZeroDivisionError(), None, memory_error])
+
+        def my_handler(ex, a, b=None):
+            return type(ex) == ZeroDivisionError
+
         with self.assertRaises(AggregateException) as new_agg_ex:
-            agg_ex.handle(lambda ex: type(ex) == ZeroDivisionError)
+            agg_ex.handle(my_handler, 1, b=True)
         self.assertIsInstance(new_agg_ex.exception, AggregateException)
         self.assertEqual([memory_error], new_agg_ex.exception.exceptions)
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -76,7 +76,7 @@ class TestGroup(unittest.TestCase):
         self.assertEquals(future.count_finished_activities, 2)
         self.assertEquals(future._result, ["test1", None, 3])
         with self.assertRaises(exceptions.ExecutionBlocked):
-            dummy = future.result
+            future.result
 
     def test_exceptions(self):
         future = Group(


### PR DESCRIPTION
Add an exception containing many inner ones, used in canvas.Group and canvas.Chain.

To be discussed.

Signed-off-by: Yves Bastide <yves@botify.com>