### PR TITLE
Propagate all decision response attributes up to Executor.replay() (#76)

### DIFF
--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -310,12 +310,13 @@ class Executor(executor.Executor):
         iterable = task.get_actual_value(iterable)
         return super(Executor, self).starmap(callable, iterable)
 
-    def replay(self, history):
+    def replay(self, decision_response):
         """Executes the workflow from the start until it blocks.
 
         """
         self.reset()
 
+        history = decision_response.history
         self._history = History(history)
         self._history.parse()
 

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -190,8 +190,6 @@ class Executor(executor.Executor):
             raise TypeError('invalid type {} for task {}'.format(
                 type(task), task))
 
-        return None
-
     def resume_activity(self, task, event):
         future = self._get_future_from_activity_event(event)
         if not future:  # Task in history does not count.

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -417,5 +417,5 @@ class Executor(executor.Executor):
         self._decisions.append(decision)
         raise exceptions.ExecutionBlocked('workflow execution failed')
 
-    def run(self, history):
-        return self.replay(history)
+    def run(self, decision_response):
+        return self.replay(decision_response)

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -187,7 +187,7 @@ class Executor(executor.Executor):
         elif isinstance(task, WorkflowTask):
             return self.find_child_workflow_event(task, history)
         else:
-            return TypeError('invalid type {} for task {}'.format(
+            raise TypeError('invalid type {} for task {}'.format(
                 type(task), task))
 
         return None

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -313,6 +313,11 @@ class Executor(executor.Executor):
     def replay(self, decision_response):
         """Executes the workflow from the start until it blocks.
 
+        :param decision_response: an object wrapping the PollForDecisionTask response
+        :type  decision_response: swf.responses.Response
+
+        :returns: a list of decision and a context dict
+        :rtype: ([swf.models.decision.base.Decision], dict)
         """
         self.reset()
 

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -214,10 +214,10 @@ class Poller(NamedMixin, swf.actors.Actor):
         self.set_process_name()
         while self.is_alive:
             try:
-                task = self._poll(self.task_list, self.identity)
+                response = self._poll(self.task_list, self.identity)
             except swf.exceptions.PollTimeout:
                 continue
-            self.process(task)
+            self.process(response)
 
     @with_state('stopping')
     def stop(self, graceful=True, join_timeout=60):
@@ -295,7 +295,7 @@ class Poller(NamedMixin, swf.actors.Actor):
 
         logger.debug("polling decision task on %s", task_list)
         try:
-            task = self.poll(
+            response = self.poll(
                 task_list,
                 identity=identity,
             )
@@ -309,4 +309,4 @@ class Poller(NamedMixin, swf.actors.Actor):
                 task_list,
             )
             raise
-        return task
+        return response

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -284,8 +284,7 @@ class Poller(NamedMixin, swf.actors.Actor):
         See also http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html#API_PollForDecisionTask_RequestSyntax
 
         :returns:
-            :rtype: (str, swf.models.History)
-
+        :rtype: swf.responses.Response
         """
         if task_list is None and self.task_list:
             task_list = self.task_list

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -110,6 +110,16 @@ class DeciderPoller(swf.actors.Decider, Poller):
         return swf.actors.Decider.complete(self, token, decisions)
 
     def process(self, decision_response):
+        """
+        Takes a PollForDecisionTask response object and tries to complete the
+        decision task, by calling self._complete() with the response token and
+        a set of decisions.
+
+        :param decision_response: an object wrapping the PollForDecisionTask response
+        :type  decision_response: swf.responses.Response
+
+        :returns: None
+        """
         logger.info('taking decision for workflow {}'.format(
             self._workflow_name))
         decisions = self.decide(decision_response)
@@ -122,6 +132,16 @@ class DeciderPoller(swf.actors.Decider, Poller):
 
     @with_state('deciding')
     def decide(self, decision_response):
+        """
+        Delegate the decision to the decider worker (which itself delegates to
+        the executor).
+
+        :param decision_response: an object wrapping the PollForDecisionTask response
+        :type  decision_response: swf.responses.Response
+
+        :returns:
+        :rtype: [swf.models.decision.base.Decision]
+        """
         worker = DeciderWorker(self._workflows)
         decisions = worker.decide(decision_response)
         return decisions
@@ -136,11 +156,11 @@ class DeciderWorker(object):
         """
         Delegate the decision to the executor.
 
-        :param history: of the workflow execution.
-        :type  history: swf.models.History.
-        :returns:
-            :rtype: (str, [swf.models.decision.base.Decision])
+        :param decision_response: an object wrapping the PollForDecisionTask response
+        :type  decision_response: swf.responses.Response
 
+        :returns:
+        :rtype: [swf.models.decision.base.Decision]
         """
         history = decision_response.history
         self._workflow_name = history[0].workflow_type['name']

--- a/swf/actors/decider.py
+++ b/swf/actors/decider.py
@@ -53,7 +53,7 @@ class Decider(Actor):
 
             raise ResponseError(e.body['message'])
 
-    def poll_for_task(self, task_list=None,
+    def poll(self, task_list=None,
              identity=None,
              **kwargs):
         """
@@ -128,8 +128,3 @@ class Decider(Actor):
 
         # TODO: move history into execution (needs refactoring on WorkflowExecution.history())
         return Response(token=token, history=history, execution=execution)
-
-
-    def poll(self, *args, **kwargs):
-        response = self.poll_for_task(*args, **kwargs)
-        return response.token, response.history

--- a/tests/swf/actors/test_decider.py
+++ b/tests/swf/actors/test_decider.py
@@ -37,26 +37,7 @@ class TestActor(unittest.TestCase):
         conn = self.make_swf_environment()
         conn.start_workflow_execution("TestDomain", "wfe-1234", "test-workflow", "v1.2")
 
-        token, history = self.actor.poll()
-
-        self.assertIsNotNone(token)
-        self.assertEquals(
-            [evt.type for evt in history],
-            ['WorkflowExecution', 'DecisionTask', 'DecisionTask']
-        )
-
-    @mock_swf
-    def test_poll_for_task_with_no_decision_to_take(self):
-        conn = self.make_swf_environment()
-        with self.assertRaises(PollTimeout):
-            self.actor.poll_for_task()
-
-    @mock_swf
-    def test_poll_for_task_with_decision_to_take(self):
-        conn = self.make_swf_environment()
-        conn.start_workflow_execution("TestDomain", "wfe-1234", "test-workflow", "v1.2")
-
-        response = self.actor.poll_for_task()
+        response = self.actor.poll()
 
         self.assertIsNotNone(response.token)
         self.assertEquals(


### PR DESCRIPTION
This implements the proposed solution to the example problem mentionned in #76, which blocks child workflows implementation and limits informations available to alerting.

Note that the change is **breaking** some interfaces (which isn't a problem if we follow semver as we didn't hit 1.0 == API stability for now), but still... I'm not happy with that but couldn't find a clean way to maintain compatibility. Our private code has to be changed accordingly if we merge this (already a PR prepared). If you think API stability is important here, shout now.

If somebody out there is using this directly, let us know.

ping @benjastudio @ybastide 