### PR TITLE
Add issubclass_ method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 import platform
 import re

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -16,7 +16,8 @@ class FuncGroup(object):
     def submit(self, executor):
         inst = self.func(*self.args, **self.kwargs)
         if not isinstance(inst, (ActivityTask, Group)):
-            raise TypeError('FuncGroup submission should return a Group or an ActivityTask, Got {} instead'.format(type(inst)))
+            raise TypeError('FuncGroup submission should return a Group or an ActivityTask,'
+                            ' got {} instead'.format(type(inst)))
         return inst.submit(executor)
 
 
@@ -59,7 +60,7 @@ class GroupFuture(futures.Future):
             return self.executor.submit(act.activity, *act.args, **act.kwargs)
         elif isinstance(act, (Group, FuncGroup)):
             return act.submit(self.executor)
-        raise TypeError('Bad type for `act` ({}). Waiting for `ActivityTask`, `Group` or `FuncGroup` instead'.format(type(act)))
+        raise TypeError('Wrong type for `act` ({}). Expecting `ActivityTask`, `Group` or `FuncGroup`'.format(type(act)))
 
     def sync_state(self):
         if all(a.finished for a in self.futures):

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -5,16 +5,11 @@ import json
 import logging
 import multiprocessing
 import os
-import platform
 import signal
-import sys
-
 from setproctitle import setproctitle
 
 import swf.actors
-
 from simpleflow import utils
-
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +276,8 @@ class Poller(NamedMixin, swf.actors.Actor):
                          defined. Minimum length of 0. Maximum length of 256.
         :type  identity: str.
 
-        See also http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html#API_PollForDecisionTask_RequestSyntax
+        See also
+        http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html#API_PollForDecisionTask_RequestSyntax
 
         :returns:
         :rtype: swf.responses.Response

--- a/simpleflow/swf/process/worker/heartbeat.py
+++ b/simpleflow/swf/process/worker/heartbeat.py
@@ -1,11 +1,9 @@
+import logging
+import multiprocessing
 import os
 import time
-import logging
-import signal
-import multiprocessing
 
 import swf.exceptions
-
 from simpleflow.utils import retry
 
 logger = logging.getLogger(__name__)
@@ -31,7 +29,6 @@ class HeartbeatProcess(object):
 
     def run(self, token, task):
         ppid = os.getppid()
-        response = {}
 
         while True:
             time.sleep(self._interval)
@@ -43,7 +40,7 @@ class HeartbeatProcess(object):
                 logger.info('heartbeat {} for task {}'.format(
                     time.time(),
                     task.activity_type.name))
-            except:
+            except Exception:
                 # Do not crash for debug
                 pass
 

--- a/simpleflow/swf/utils.py
+++ b/simpleflow/swf/utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
+
 import swf.models
 import swf.querysets
-
 from simpleflow.history import History
 
 

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-import json
 import abc
-import collections
+import json
 
 from . import futures
 from .activity import Activity

--- a/simpleflow/utils/__init__.py
+++ b/simpleflow/utils/__init__.py
@@ -1,4 +1,4 @@
-from . import retry
+from . import retry  # NOQA
 
 
 def issubclass_(arg1, arg2):

--- a/simpleflow/utils/__init__.py
+++ b/simpleflow/utils/__init__.py
@@ -1,1 +1,8 @@
 from . import retry
+
+
+def issubclass_(arg1, arg2):
+    try:
+        return issubclass(arg1, arg2)
+    except TypeError:
+        return False

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 
 from simpleflow.utils import issubclass_
-from .activity import Activity
 from . import canvas
 from . import task
 from ._decorators import deprecated
-
-import inspect
+from .activity import Activity
 
 
 class Workflow(object):
@@ -25,11 +23,11 @@ class Workflow(object):
         Submit a function for asynchronous execution.
 
         :param activity: callable registered as an task.
-        :type  activity: activity.Activity | task.ActivityTask | task.WorkflowTask | canvas.Group | canvas.Chain | workflow.Workflow
-        :param *args: arguments passed to the task.
-        :type  *args: Sequence.
-        :param **kwargs: keyword-arguments passed to the task.
-        :type  **kwargs: Mapping (dict).
+        :type  activity: Activity | task.ActivityTask | task.WorkflowTask | canvas.Group | canvas.Chain | Workflow
+        :param args: arguments passed to the task.
+        :type  args: Sequence.
+        :param kwargs: keyword-arguments passed to the task.
+        :type  kwargs: Mapping (dict).
 
         :returns:
             :rtype: Future.

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+from simpleflow.utils import issubclass_
 from .activity import Activity
 from . import canvas
 from . import task
@@ -35,7 +37,7 @@ class Workflow(object):
         """
         # If the activity is a child workflow, call directly
         # the executor
-        if inspect.isclass(activity) and issubclass(activity, Workflow):
+        if issubclass_(activity, Workflow):
             return self._executor.submit(activity, *args, **kwargs)
         elif isinstance(activity, (task.ActivityTask, task.WorkflowTask)):
             return self._executor.submit(activity.activity, *activity.args, **activity.kwargs)


### PR DESCRIPTION
issubclass(D, C) raises a TypeError if D is not a class: this is not
amusing in our use cases (checking if a `func` is a Workflow).

We've used two types of protection against this:

* wrap the test in a try..except TypeError
* first use inspect.isclass

A "standard" workaround is what Numpy does: define an `issubclass_`
method, catching and ignoring the TypeError. Let's do this.

What else crept in this PR:

* some parameter renaming task → a_task, to not hide the import task
* some instance → static method thansformations
* some except X as x rewriting (Py3k syntax)

Signed-off-by: Yves Bastide <yves@botify.com>