### PR TITLE
Avoid duplicate logs if root logger has an handler

### DIFF
--- a/simpleflow/settings/default.py
+++ b/simpleflow/settings/default.py
@@ -24,6 +24,8 @@ LOGGING = {
         'simpleflow': {
             'level': os.getenv('LOG_LEVEL', 'INFO'),
             'handlers': ['console'],
+            # avoid duplicate logs if loggers up are defined (e.g. root)
+            'propagate': False,
         },
     },
     'handlers': {


### PR DESCRIPTION
Without this fix:
```
$ AWS_DEFAULT_REGION=eu-west-1 simpleflow decider.start my.Workflow --domain xxxxx --task-list tl --nb-processes 1
2016-05-31T13:42:58 INFO [process=MainProcess, pid=18241]: starting <bound method DeciderPoller.start of DeciderPoller(xxxxx, tl, xx)>
starting <bound method DeciderPoller.start of DeciderPoller(xxxxx, tl, xx)>
2016-05-31T13:42:58 INFO [process=Process-1, pid=18248]: starting DeciderPoller(workflow=job) on domain xxxxx
starting DeciderPoller(workflow=xx) on domain xxxxx
```

Same with this fix:
```
$ AWS_DEFAULT_REGION=eu-west-1 simpleflow decider.start my.Workflow --domain xxxxx --task-list tl --nb-processes 1
2016-05-31T13:42:58 INFO [process=MainProcess, pid=18241]: starting <bound method DeciderPoller.start of DeciderPoller(xxxxx, tl, xx)>
2016-05-31T13:42:58 INFO [process=Process-1, pid=18248]: starting DeciderPoller(workflow=xx) on domain xxxxx
```

But maybe it's better to leave the code of the workflow handle that? simpleflow's own logging is better than our internal code for now, so if you prefer the private code to handle that case I'd be happy to have an example or suggestions

ping @benjastudio @ybastide 