### PR TITLE
Allow passing SWF domain via the SWF_DOMAIN environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,20 @@ Start an activity worker with: ::
 
 Then execute ``./demo``.
 
+Controlling SWF region and domain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SWF region is controlled by the environment variable ``AWS_DEFAULT_REGION``. This variable
+comes from the legacy "simple-workflow" project. The option might be exposed through a
+``--region`` option in the future (if you want that, please open an issue).
+
+The SWF domain is controlled by the ``--domain`` on most simpleflow commands. It can also
+be set via the ``SWF_DOMAIN`` environment variable. In case both are supplied, the
+command-line value takes precedence over the environment variable.
+
+Note that some simpleflow commands expect the domain to be passed as a positionnal argument.
+In that case the environment variable has no effect for now.
+
 List Workflow Executions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -96,6 +96,7 @@ def transform_input(wf_input):
               required=False,
               help='ID of the workflow execution.')
 @click.option('--domain',
+              envvar='SWF_DOMAIN',
               required=False,
               help='Amazon SWF Domain.')
 @click.argument('workflow')
@@ -285,7 +286,10 @@ def task_info(ctx, domain, workflow_id, task_id, details):
 @click.option('--nb-processes', '-N', type=int)
 @click.option('--log-level', '-l')
 @click.option('--task-list')
-@click.option('--domain', '-d', required=True, help='SWF Domain')
+@click.option('--domain', '-d',
+              envvar='SWF_DOMAIN',
+              required=True,
+              help='SWF Domain')
 @click.argument('workflows', nargs=-1, required=True)
 @cli.command('decider.start', help='Start a decider process to manage workflow executions.')
 def start_decider(workflows, domain, task_list, log_level, nb_processes):
@@ -309,7 +313,10 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
 @click.option('--nb-processes', '-N', type=int)
 @click.option('--log-level', '-l')
 @click.option('--task-list')
-@click.option('--domain', '-d', required=True, help='SWF Domain')
+@click.option('--domain', '-d',
+              envvar='SWF_DOMAIN',
+              required=True,
+              help='SWF Domain')
 @click.argument('workflow')
 @cli.command('worker.start', help='Start a worker process to handle activity tasks.')
 def start_worker(workflow, domain, task_list, log_level, nb_processes, heartbeat):
@@ -364,6 +371,7 @@ def get_task_list(workflow_id=''):
               required=False,
               help='ID of the workflow execution.')
 @click.option('--domain', '-d',
+              envvar='SWF_DOMAIN',
               required=True,
               help='SWF Domain.')
 @click.option('--display-status',


### PR DESCRIPTION
This will allow to launch simpleflow processes via the same command-line and control the domain (which, in Botify private code is specific to an environment, e.g. staging, production, etc.) via the environment.