### PR TITLE
Fix --tags argument for simpleflow standalone and workflow.start

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -51,6 +51,13 @@ def disable_boto_connection_pooling():
     boto.connection.ON_APP_ENGINE = True
 
 
+def comma_separated_list(value):
+    """
+    Transforms a comma-separated list into a list of strigns.
+    """
+    return value.split(",")
+
+
 @click.group()
 @click.option('--format')
 @click.option('--header/--no-header', default=False)
@@ -107,6 +114,7 @@ def transform_input(wf_input):
               required=False, type=click.File(),
               help='JSON file with the input of the workflow.')
 @click.option('--tags',
+              type=comma_separated_list,
               required=False,
               help='Tags for the workflow execution.')
 @click.option('--decision-tasks-timeout',
@@ -383,6 +391,7 @@ def get_task_list(workflow_id=''):
               required=False, type=click.File(),
               help='JSON file with the input of the workflow.')
 @click.option('--tags',
+              type=comma_separated_list,
               required=False,
               help='Tags identifying the workflow execution.')
 @click.option('--decision-tasks-timeout',

--- a/swf/models/workflow.py
+++ b/swf/models/workflow.py
@@ -258,6 +258,10 @@ class WorkflowType(BaseModel):
         input = json.dumps(input) or None
         tag_list = tag_list if isinstance(tag_list, list) else [tag_list]
 
+        # checks
+        if len(tag_list) > 5:
+            raise ValueError("You cannot have more than 5 tags in StartWorkflowExecution.")
+
         run_id = self.connection.start_workflow_execution(
             self.domain.name,
             workflow_id,

--- a/swf/models/workflow.py
+++ b/swf/models/workflow.py
@@ -246,7 +246,7 @@ class WorkflowType(BaseModel):
         :type   input: dict
 
         :param  tag_list: Tags associated with the workflow execution
-        :type   tag_list: String
+        :type   tag_list: String or list of strings
 
         :param  decision_tasks_timeout: maximum duration of decision tasks
                                         for this workflow execution
@@ -256,6 +256,7 @@ class WorkflowType(BaseModel):
         task_list = task_list or self.task_list
         child_policy = child_policy or self.child_policy
         input = json.dumps(input) or None
+        tag_list = tag_list if isinstance(tag_list, list) else [tag_list]
 
         run_id = self.connection.start_workflow_execution(
             self.domain.name,


### PR DESCRIPTION
Fixes #113 

The type of the `--tag` will be evaluated when parsing the command, and I also added a safeguard inside the function as discussed in case the passed parameter is not a list.

I'll integrate it into the next version of simpleflow, probably tomorrow.