### PR TITLE
Improve tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 invoke
 mock==1.0.1
 moto>=0.4.19
-pytest
+pytest==3.0.1
 sphinx
 sphinx_rtd_theme
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,6 @@ moto>=0.4.19
 pytest==3.0.1
 sphinx
 sphinx_rtd_theme
+sure==1.4.0
+vcrpy==1.10.0
 wheel

--- a/script/test
+++ b/script/test
@@ -6,8 +6,11 @@
 unset AWS_DEFAULT_REGION
 
 # Disable AWS credentials
-unset AWS_ACCESS_KEY_ID
-unset AWS_SECRET_ACCESS_KEY
+# NB: we set them to wrong values so boto believes they're here, so it
+# issues integration requests later catched by VCR. For more information
+# see tests/integration/README.md
+export AWS_ACCESS_KEY_ID=1234
+export AWS_SECRET_ACCESS_KEY=1234
 
 # Enable various test optimizations
 export SIMPLEFLOW_ENV=test

--- a/script/test
+++ b/script/test
@@ -1,10 +1,16 @@
 #!/bin/bash
-set -x
 
 # The AWS_DEFAULT_REGION parameter determines the region used for SWF
 # Leaving it to a value different than "us-east-1" would break moto,
 # because moto.swf only mocks calls to us-east-1 region for now.
 unset AWS_DEFAULT_REGION
+
+# Disable AWS credentials
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+
+# Enable various test optimizations
+export SIMPLEFLOW_ENV=test
 
 # Simple variable to control the number of connection retries
 export SWF_CONNECTION_RETRIES=1

--- a/simpleflow/swf/constants.py
+++ b/simpleflow/swf/constants.py
@@ -1,4 +1,11 @@
 import os
 
-MAX_DECISIONS = 100
-MAX_OPEN_ACTIVITY_COUNT = int(os.getenv("SWF_MAX_OPEN_ACTIVITY_COUNT", 1000))
+SIMPLEFLOW_ENV = os.getenv("SIMPLEFLOW_ENV", "production")
+
+# We lower some constants in test environment so tests run faster
+if SIMPLEFLOW_ENV == "test":
+    MAX_DECISIONS = 10
+    MAX_OPEN_ACTIVITY_COUNT = 15
+else:
+    MAX_DECISIONS = 100
+    MAX_OPEN_ACTIVITY_COUNT = int(os.getenv("SWF_MAX_OPEN_ACTIVITY_COUNT", 1000))

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,29 @@
+# simpleflow integration tests
+
+Integration tests in this directory are meant to hit the real SWF endpoints.
+They trigger real API calls, via simpleflow commands, simpleflow functions or
+direct boto calls, and check that everything interacts correctly with the SWF
+API.
+
+Of course this is not suitable for running the test suite on travis-ci. So the
+tests here use [vcrpy](https://vcrpy.readthedocs.io/), a port of the popular
+ruby gem: it records HTTP interactions and replay them from the local cache
+(called a "cassette") when possible. Cassettes can be refreshed by simply
+removing them, which will force real HTTP hits again. Note that for this to
+work, you need to have valid SWF credentials for your account on the region
+`us-east-1` and the domain `TestDomain` (this is set in `__init__.py` in this
+directory).
+
+To sum up:
+
+    # first run: hits SWF APIs, populate the ./cassettes/ directory with
+    # serialized resquests/responses
+    py.test -v tests/integration/
+
+    # second run (and next): no hit to the SWF APIs are made, requests
+    # are replayed from what has been recorded in the first run
+    py.test -v tests/integration/
+
+    # if you need to refresh cassettes (a good idea from time to time):
+    rm -rf tests/integration/cassettes/*.yaml
+    py.test -v tests/integration/

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,24 @@
+import inspect
+import os
+
+from vcr import VCR
+
+
+# Default SWF parameters
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["SWF_DOMAIN"] = "TestDomain"
+
+
+# VCR config with better defaults for SWF API calls
+def test_name_to_cassette_path(function):
+    name = function.__name__
+    directory = os.path.dirname(inspect.getfile(function))
+    return os.path.join(directory, "cassettes", name + ".yaml")
+
+
+vcr = VCR(
+    func_path_generator=test_name_to_cassette_path,
+    filter_headers=[
+        ("Authorization", "AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar"),
+    ],
+)

--- a/tests/integration/cassettes/test_simpleflow_workflow_start.yaml
+++ b/tests/integration/cassettes/test_simpleflow_workflow_start.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "workflowType": {"version": "example",
+      "name": "basic"}}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['81']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003114Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.DescribeWorkflowType]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"configuration":{"defaultChildPolicy":"TERMINATE","defaultExecutionStartToCloseTimeout":"300","defaultTaskList":{"name":"None"},"defaultTaskStartToCloseTimeout":"300"},"typeInfo":{"creationDate":1.435159034741E9,"status":"REGISTERED","workflowType":{"name":"basic","version":"example"}}}'}
+    headers:
+      content-length: ['288']
+      content-type: [application/json]
+      x-amzn-requestid: [10eb0cba-6992-11e6-a4f9-8defff707f7a]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "taskList": {"name": "test"},
+      "childPolicy": "TERMINATE", "executionStartToCloseTimeout": "300", "input":
+      "null", "workflowType": {"version": "example", "name": "basic"}, "taskStartToCloseTimeout":
+      "30", "workflowId": "test-simpleflow-workflow"}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['270']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003115Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.StartWorkflowExecution]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"runId":"22Pij42qQYS4zptpD4JBqrvr24zGnPxT9rTOkGXVcZVhA="}'}
+    headers:
+      content-length: ['58']
+      content-type: [application/json]
+      x-amzn-requestid: [112a384d-6992-11e6-9939-277c426610ce]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "startTimeFilter": {"oldestDate":
+      0}, "executionFilter": {"workflowId": "test-simpleflow-workflow"}}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['125']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003115Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.ListOpenWorkflowExecutions]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"executionInfos":[{"cancelRequested":false,"execution":{"runId":"22Pij42qQYS4zptpD4JBqrvr24zGnPxT9rTOkGXVcZVhA=","workflowId":"test-simpleflow-workflow"},"executionStatus":"OPEN","startTimestamp":1.471998675578E9,"workflowType":{"name":"basic","version":"example"}}]}'}
+    headers:
+      content-length: ['268']
+      content-type: [application/json]
+      x-amzn-requestid: [11760eaf-6992-11e6-8ff3-49d50afed315]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "workflowId": "test-simpleflow-workflow"}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['66']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003116Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.TerminateWorkflowExecution]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-length: ['0']
+      content-type: [application/json]
+      x-amzn-requestid: [11885e57-6992-11e6-8ff3-49d50afed315]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/integration/cassettes/test_simpleflow_workflow_terminate.yaml
+++ b/tests/integration/cassettes/test_simpleflow_workflow_terminate.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "workflowType": {"version": "example",
+      "name": "basic"}}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['81']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003116Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.DescribeWorkflowType]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"configuration":{"defaultChildPolicy":"TERMINATE","defaultExecutionStartToCloseTimeout":"300","defaultTaskList":{"name":"None"},"defaultTaskStartToCloseTimeout":"300"},"typeInfo":{"creationDate":1.435159034741E9,"status":"REGISTERED","workflowType":{"name":"basic","version":"example"}}}'}
+    headers:
+      content-length: ['288']
+      content-type: [application/json]
+      x-amzn-requestid: [11ca48da-6992-11e6-b609-b16989579c3e]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "taskList": {"name": "test"},
+      "childPolicy": "TERMINATE", "executionStartToCloseTimeout": "300", "input":
+      "null", "workflowType": {"version": "example", "name": "basic"}, "taskStartToCloseTimeout":
+      "30", "workflowId": "test-simpleflow-workflow"}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['270']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003116Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.StartWorkflowExecution]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"runId":"22yHsprtmgzTx4tPK3+2bdpN3BYZkk5ff+lUc0Khkupcg="}'}
+    headers:
+      content-length: ['58']
+      content-type: [application/json]
+      x-amzn-requestid: [120a383c-6992-11e6-9a56-dd21d5d7fedf]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "startTimeFilter": {"oldestDate":
+      1469406677}, "executionFilter": {"workflowId": "test-simpleflow-workflow"}}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['134']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003117Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.ListOpenWorkflowExecutions]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode '{"executionInfos":[{"cancelRequested":false,"execution":{"runId":"22yHsprtmgzTx4tPK3+2bdpN3BYZkk5ff+lUc0Khkupcg=","workflowId":"test-simpleflow-workflow"},"executionStatus":"OPEN","startTimestamp":1.471998677044E9,"workflowType":{"name":"basic","version":"example"}}]}'}
+    headers:
+      content-length: ['268']
+      content-type: [application/json]
+      x-amzn-requestid: [12599103-6992-11e6-9e4e-552b95b37287]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"domain": "TestDomain", "workflowId": "test-simpleflow-workflow",
+      "runId": "22yHsprtmgzTx4tPK3+2bdpN3BYZkk5ff+lUc0Khkupcg="}'
+    headers:
+      Authorization: ['AWS4-HMAC-SHA256 Credential=1234AB/20160823/us-east-1/swf/aws4_request,SignedHeaders=host;x-amz-date;x-amz-target,Signature=foobar']
+      Content-Encoding: [amz-1.0]
+      Content-Length: ['125']
+      Content-Type: [application/json; charset=UTF-8]
+      Host: [swf.us-east-1.amazonaws.com]
+      User-Agent: [Boto/2.38.0 Python/2.7.10 Darwin/14.5.0]
+      X-Amz-Date: [20160824T003117Z]
+      X-Amz-Target: [com.amazonaws.swf.service.model.SimpleWorkflowService.TerminateWorkflowExecution]
+    method: POST
+    uri: https://swf.us-east-1.amazonaws.com/
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-length: ['0']
+      content-type: [application/json]
+      x-amzn-requestid: [1297d29f-6992-11e6-a168-e31eaef39470]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -1,0 +1,102 @@
+# See README for more informations about integration testsimport sys
+import os
+import unittest
+
+import boto.swf
+from click.testing import CliRunner
+from sure import expect
+
+import simpleflow.command
+from . import vcr
+
+
+WORKFLOW_ID = "test-simpleflow-workflow"
+
+
+class TestSimpleflowCommand(unittest.TestCase):
+    @property
+    def region(self):
+        return os.environ["AWS_DEFAULT_REGION"]
+
+    @property
+    def domain(self):
+        return os.environ["SWF_DOMAIN"]
+
+    def invoke(self, command, arguments):
+        if not hasattr(self, "runner"):
+            self.runner = CliRunner()
+        return self.runner.invoke(command, arguments.split(" "))
+
+    @property
+    def conn(self):
+        if not hasattr(self, "_conn"):
+            self._conn = boto.swf.connect_to_region(self.region)
+        return self._conn
+
+    def cleanup(self):
+        # ideally this should be in a tearDown() or setUp() call, but those
+        # calls play badly with VCR since they only happen "sometimes"... :-/
+        self.conn.terminate_workflow_execution(self.domain, WORKFLOW_ID)
+
+    @vcr.use_cassette
+    def test_simpleflow_workflow_start(self):
+        """
+        Tests simpleflow workflow.start
+        """
+        # start a workflow
+        result = self.invoke(
+            simpleflow.command.cli,
+            "workflow.start --workflow-id {} --task-list test --input null "
+            "--execution-timeout 300 --decision-tasks-timeout 30 "
+            "tests.integration.workflow.SleepWorkflow".format(WORKFLOW_ID)
+        )
+
+        # check response form: "<workflow id> <run-id>"
+        expect(result.exit_code).to.equal(0)
+        wf_id, run_id = result.output.split()
+        expect(wf_id).to.equal(WORKFLOW_ID)
+
+        # check against SWF that execution is launched
+        executions = self.conn.list_open_workflow_executions(
+            self.domain, 0, workflow_id=WORKFLOW_ID
+        )
+        items = executions["executionInfos"]
+        expect(len(items)).to.equal(1)
+        expect(items[0]["execution"]["runId"]).to.equal(run_id)
+
+        # kill the workflow now
+        self.cleanup()
+
+    @vcr.use_cassette
+    def test_simpleflow_workflow_terminate(self):
+        """
+        Tests simpleflow workflow.terminate
+        """
+        # start a workflow (easier with simpleflow command)
+        self.invoke(
+            simpleflow.command.cli,
+            "workflow.start --workflow-id {} --task-list test --input null "
+            "--execution-timeout 300 --decision-tasks-timeout 30 "
+            "tests.integration.workflow.SleepWorkflow".format(WORKFLOW_ID)
+        )
+
+        # now try to terminate it
+        result = self.invoke(
+            simpleflow.command.cli,
+            "workflow.terminate {} {}".format(self.domain, WORKFLOW_ID),
+        )
+
+        # check response form (empty)
+        expect(result.exit_code).to.equal(0)
+        expect(result.output).to.equal("")
+
+    # TODO: simpleflow decider.start
+    # TODO: simpleflow standalone
+    # TODO: simpleflow task.info
+    # TODO: simpleflow worker.start
+    # TODO: simpleflow workflow.filter
+    # TODO: simpleflow workflow.info
+    # TODO: simpleflow workflow.list
+    # TODO: simpleflow workflow.profile
+    # TODO: simpleflow workflow.restart
+    # TODO: simpleflow workflow.tasks

--- a/tests/integration/workflow.py
+++ b/tests/integration/workflow.py
@@ -1,0 +1,25 @@
+import time
+
+from simpleflow import (
+    activity,
+    Workflow,
+    futures,
+)
+
+
+@activity.with_attributes(task_list='quickstart', version='example',
+                          start_to_close_timeout=60, heartbeat_timeout=15,
+                          raises_on_failure=True)
+def sleep():
+    print "will sleep"
+    time.sleep(30)
+    print "good sleep"
+
+class SleepWorkflow(Workflow):
+    name = 'basic'
+    version = 'example'
+    task_list = 'example'
+
+    def run(self):
+        x = self.submit(sleep)
+        futures.wait(x)

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -822,7 +822,7 @@ class TestDefinitionMoreThanMaxDecisions(TestWorkflow):
     decider can take once.
     """
     def run(self):
-        results = self.map(increment, xrange(constants.MAX_DECISIONS + 20))
+        results = self.map(increment, xrange(constants.MAX_DECISIONS + 5))
         futures.wait(*results)
 
 
@@ -852,11 +852,11 @@ def test_workflow_with_more_than_max_decisions():
         .add_decision_task_started())
 
     # Once the first batch of ``constants.MAX_DECISIONS`` tasks is finished,
-    # the executor should schedule the 20 remaining ones.
+    # the executor should schedule the 5 remaining ones.
     decisions, _ = executor.replay(Response(history=history))
-    assert len(decisions) == 20
+    assert len(decisions) == 5
 
-    for i in xrange(constants.MAX_DECISIONS - 1, constants.MAX_DECISIONS + 20):
+    for i in xrange(constants.MAX_DECISIONS - 1, constants.MAX_DECISIONS + 5):
         history.add_activity_task(
             increment,
             decision_id=decision_id,
@@ -1187,7 +1187,7 @@ class TestDefinitionMoreThanMaxOpenActivities(TestWorkflow):
     def run(self):
         results = self.map(
             increment,
-            xrange(constants.MAX_OPEN_ACTIVITY_COUNT + 20))
+            xrange(constants.MAX_OPEN_ACTIVITY_COUNT + 5))
         futures.wait(*results)
 
 
@@ -1315,9 +1315,9 @@ def test_more_than_1000_open_activities_partial_max():
         .add_decision_task_started())
 
     decisions, _ = executor.replay(Response(history=history))
-    # 2 already scheduled + 20 to schedule now
-    assert executor._open_activity_count == 22
-    assert len(decisions) == 20
+    # 2 already scheduled + 5 to schedule now
+    assert executor._open_activity_count == 7
+    assert len(decisions) == 5
 
 
 

--- a/tests/test_swf/models/test_workflow.py
+++ b/tests/test_swf/models/test_workflow.py
@@ -95,8 +95,8 @@ class TestWorkflowType(unittest.TestCase):
 
             self.assertFalse(self.wt.exists)
 
-    # TODO: this test blocks badly if no network connection, I suspect it reaches
-    # the real SWF endpoints in some way.
+    # TODO: fix test when no network (probably hits real SWF endpoints)
+    @unittest.skip("Skip it in case there's no network connection.")
     def test_workflow_type_exists_with_whatever_error(self):
         with patch.object(self.wt.connection, 'describe_workflow_type') as mock:
             with self.assertRaises(ResponseError):
@@ -306,6 +306,8 @@ class TestWorkflowExecution(unittest.TestCase):
 
             self.assertFalse(self.we.exists)
 
+    # TODO: fix test when no network (probably hits real SWF endpoints)
+    @unittest.skip("Skip it in case there's no network connection.")
     def test_workflow_execution_exists_with_whatever_error(self):
         with patch.object(self.we.connection, 'describe_workflow_execution') as mock:
             with self.assertRaises(ResponseError):


### PR DESCRIPTION
Extracted the tests improvement I initially did in #110:
- skip some bad tests that mock things incompletely (hence fail when no network is available)
- improve some existing tests
- add integration tests (but don't hit real SWF APIs when on Travis, thanks to VCRpy, see commits and README)

These are just minor enhancements but I'd like to merge them soon so I can build on that for other things (recently: I would have add integration tests for recent fixes on the "--tags" option for instance).

ping @ybastide @ampelmann @benjastudio 