### PR TITLE
Enhancement/126/use compact json dumps where possible

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -522,7 +522,7 @@ def standalone(context,
         execution_timeout,
         tags,
         decision_tasks_timeout,
-        json.dumps(wf_input),
+        json_dumps(wf_input),
         None,
         local=False,
     )
@@ -604,4 +604,4 @@ def activity_rerun(domain,
 
     # finally replay the function with the correct arguments
     result = func(*args, **kwargs)
-    logger.info("Result (JSON): {}".format(json_dumps(result)))
+    logger.info("Result (JSON): {}".format(json_dumps(result, pretty=True)))

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -605,4 +605,4 @@ def activity_rerun(domain,
 
     # finally replay the function with the correct arguments
     result = func(*args, **kwargs)
-    logger.info("Result (JSON): {}".format(json_dumps(result, pretty=True)))
+    logger.info("Result (JSON): {}".format(json_dumps(result, compact=False)))

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -41,7 +41,8 @@ def disable_boto_connection_pooling():
     # boto connection pooling doesn't work very well with multiprocessing, it
     # provokes some errors like this:
     #
-    #    [Errno 1] _ssl.c:1429: error:1408F119:SSL routines:SSL3_GET_RECORD:decryption failed or bad record mac when polling on analysis-testjbb-repair-a61ff96e854344748e308fefc9ddff61
+    #    [Errno 1] _ssl.c:1429: error:1408F119:SSL routines:SSL3_GET_RECORD:decryption failed or bad record mac
+    # when polling on analysis-testjbb-repair-a61ff96e854344748e308fefc9ddff61
     #
     # It's because when forking, file handles are copied and sockets are shared.
     # Even sockets that handle SSL conections to AWS services, but SSL

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -8,6 +8,8 @@ import base64
 import logging
 import types
 
+from simpleflow.utils import json_dumps
+
 __all__ = ['program', 'python']
 
 
@@ -93,7 +95,7 @@ def check_keyword_arguments(argspec, kwargs):
 
 
 def format_arguments_json(*args, **kwargs):
-    return json.dumps({
+    return json_dumps({
         'args': args,
         'kwargs': kwargs,
     })
@@ -367,4 +369,4 @@ if __name__ == '__main__':
             pickle.dumps(err)))
         sys.exit(1)
     else:
-        print(json.dumps(result))
+        print(json_dumps(result))

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 import sys
 import subprocess

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -502,7 +502,7 @@ class Executor(executor.Executor):
 
         self.after_replay()
         decision = swf.models.decision.WorkflowExecutionDecision()
-        decision.complete(result=swf.format.result(json.dumps(result)))
+        decision.complete(result=swf.format.result(json_dumps(result)))
         self.on_completed()
         self.after_closed()
         return [decision], {}

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -30,7 +30,6 @@ from swf.core import ConnectedSWFObject
 
 logger = logging.getLogger(__name__)
 
-
 __all__ = ['Executor']
 
 
@@ -52,6 +51,7 @@ def run_fake_activity_task(domain, task_list, result):
         result,
     )
 
+
 # TODO: test that correctly! At the time of writing this I don't have any real
 # world crawl containing child workflows, so this is not guaranteed to work the
 # first time, and it's a bit hard to test end-to-end even with moto.mock_swf
@@ -64,8 +64,8 @@ def run_fake_activity_task(domain, task_list, result):
                   delay=retry.exponential,
                   on_exceptions=KeyError)
 def run_fake_child_workflow_task(domain, task_list, workflow_type_name,
-        workflow_type_version, workflow_id, input=None, result=None,
-        child_policy=None, control=None, tag_list=None):
+                                 workflow_type_version, workflow_id, input=None, result=None,
+                                 child_policy=None, control=None, tag_list=None):
     conn = ConnectedSWFObject().connection
     conn.start_child_workflow_execution(
         workflow_type_name, workflow_type_version, workflow_id,
@@ -107,9 +107,9 @@ def run_fake_task_worker(domain, task_list, former_event):
                 domain,
                 task_list,
                 former_event['result'],
-                former_event['name'],     # workflow_type_name
+                former_event['name'],  # workflow_type_name
                 former_event['version'],  # workflow_type_version
-                former_event['id'],       # workflow_id
+                former_event['id'],  # workflow_id
             ),
             kwargs={
                 'input': former_event['raw_input'],
@@ -126,6 +126,7 @@ class TaskRegistry(dict):
     """This registry tracks tasks and assign them an integer identifier.
 
     """
+
     def add(self, a_task):
         """
         ID's are assigned sequentially by incrementing an integer. They start
@@ -154,6 +155,7 @@ class Executor(executor.Executor):
     on the execution of the workflow.
 
     """
+
     def __init__(self, domain, workflow, task_list=None, repair_with=None,
                  force_activities=None):
         super(Executor, self).__init__(workflow)
@@ -353,8 +355,8 @@ class Executor(executor.Executor):
         future = None
 
         # check if we absolutely want to execute this task in repair mode
-        force_execution = self.force_activities and \
-            self.force_activities.search(a_task.id)
+        force_execution = (self.force_activities and
+                           self.force_activities.search(a_task.id))
 
         # try to fill in the blanks with the workflow we're trying to repair if any
         # TODO: maybe only do that for idempotent tasks??
@@ -364,7 +366,7 @@ class Executor(executor.Executor):
             # ... but only keep the event if the task was successful
             if former_event and former_event['state'] == 'completed':
                 logger.info(
-                    'faking task completed successfully in previous ' \
+                    'faking task completed successfully in previous '
                     'workflow: {}'.format(former_event['id'])
                 )
                 json_hash = hashlib.md5(json_dumps(former_event)).hexdigest()
@@ -410,7 +412,7 @@ class Executor(executor.Executor):
                 a_task = WorkflowTask(func, *args, **kwargs)
             else:
                 raise TypeError('invalid type {} for {}'.format(
-                                type(func), func))
+                    type(func), func))
         except exceptions.ExecutionBlocked:
             return futures.Future()
 

--- a/simpleflow/swf/helpers.py
+++ b/simpleflow/swf/helpers.py
@@ -10,6 +10,7 @@ import swf.models
 import swf.querysets
 import swf.exceptions
 from simpleflow.activity import Activity
+from simpleflow.utils import json_dumps
 
 from .stats import pretty
 
@@ -135,7 +136,7 @@ def get_task(domain_name, workflow_id, task_id, details):
 
 
 def swf_identity():
-    return json.dumps({
+    return json_dumps({
         'user': getpass.getuser(),          # system's user
         'hostname': socket.gethostname(),   # main hostname
         'pid': os.getpid(),                 # current pid

--- a/simpleflow/swf/helpers.py
+++ b/simpleflow/swf/helpers.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import
 
 import getpass
-from importlib import import_module
-import json
 import os
 import socket
+from importlib import import_module
 
+import swf.exceptions
 import swf.models
 import swf.querysets
-import swf.exceptions
 from simpleflow.activity import Activity
 from simpleflow.utils import json_dumps
 

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -8,7 +8,7 @@ from . import (
 
 
 def load_workflow(domain, workflow_name, task_list=None, repair_with=None,
-        force_activities=None):
+                  force_activities=None):
     module_name, object_name = workflow_name.rsplit('.', 1)
     module = __import__(module_name, fromlist=['*'])
 
@@ -33,7 +33,7 @@ def make_decider_poller(workflows, domain, task_list, repair_with=None,
         load_workflow(domain, workflow, task_list, repair_with=repair_with,
                       force_activities=force_activities)
         for workflow in workflows
-    ]
+        ]
     domain = swf.models.Domain(domain)
     return DeciderPoller(executors, domain, task_list)
 

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -16,6 +16,8 @@ from simpleflow.swf.process.actor import (
     with_state,
 )
 from simpleflow.swf.task import ActivityTask
+from simpleflow.utils import json_dumps
+
 from .dispatch import from_task_registry
 
 
@@ -114,7 +116,7 @@ class ActivityWorker(object):
             return poller.fail(token, task, reason=str(err), details=tb)
 
         try:
-            poller._complete(token, json.dumps(result))
+            poller._complete(token, json_dumps(result))
         except Exception as err:
             logger.exception("complete error")
             reason = 'cannot complete task {}: {}'.format(

--- a/simpleflow/swf/stats/pretty.py
+++ b/simpleflow/swf/stats/pretty.py
@@ -1,13 +1,12 @@
-import sys
 import operator
-from functools import partial, wraps
 from datetime import datetime
+from functools import partial, wraps
 
+from simpleflow.history import History
+from simpleflow.utils import json_dumps
 from tabulate import tabulate
 
 from . import WorkflowStats
-from simpleflow.history import History
-from simpleflow.utils import json_dumps
 
 TEMPLATE = '''
 Workflow Execution {workflow_id}

--- a/simpleflow/swf/utils.py
+++ b/simpleflow/swf/utils.py
@@ -16,8 +16,8 @@ def get_workflow_execution(domain_name, workflow_id, run_id=None):
     if not run_id:
         found_run_id = None
         qs = swf.querysets.WorkflowExecutionQuerySet(domain)
-        wfe = qs.filter(workflow_id=workflow_id, status=swf.models.WorkflowExecution.STATUS_OPEN) or \
-                qs.filter(workflow_id=workflow_id, status=swf.models.WorkflowExecution.STATUS_CLOSED)
+        wfe = (qs.filter(workflow_id=workflow_id, status=swf.models.WorkflowExecution.STATUS_OPEN) or
+               qs.filter(workflow_id=workflow_id, status=swf.models.WorkflowExecution.STATUS_CLOSED))
         if wfe:
             # by default, workflow executions are returned in descending start time order
             # so the first returned is the last that has run
@@ -30,6 +30,7 @@ def get_workflow_execution(domain_name, workflow_id, run_id=None):
         workflow_id=workflow_id,
         run_id=run_id or found_run_id,
     )
+
 
 # TODO: move this function inside a QuerySet object when we merge the
 # "simpleflow" and "swf" namespaces

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import abc
-import json
 
 from simpleflow.utils import json_dumps
 

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import abc
 import json
 
+from simpleflow.utils import json_dumps
+
 from . import futures
 from .activity import Activity
 
@@ -27,7 +29,7 @@ class Task(object):
         raise NotImplementedError()
 
     def serialize(self, value):
-        return json.dumps(value)
+        return json_dumps(value)
 
     def resolve_args(self, *args):
         return [get_actual_value(arg) for arg in args]

--- a/simpleflow/utils/__init__.py
+++ b/simpleflow/utils/__init__.py
@@ -1,5 +1,5 @@
 from . import retry  # NOQA
-from .json_dumps import json_dumps
+from .json_dumps import json_dumps  # NOQA
 
 
 def issubclass_(arg1, arg2):

--- a/simpleflow/utils/json_dumps.py
+++ b/simpleflow/utils/json_dumps.py
@@ -13,7 +13,18 @@ def _serialize_complex_object(obj):
         " please file a new issue on GitHub!" % type(obj))
 
 
-def json_dumps(obj, pretty=False):
+def json_dumps(obj, pretty=False, compact=True):
+    """
+    JSON dump to string.
+    :param obj:
+    :type obj: Any
+    :param pretty:
+    :type pretty: bool
+    :param compact:
+    :type compact: bool
+    :return:
+    :rtype: str
+    """
     kwargs = {
         "default": _serialize_complex_object
     }
@@ -21,4 +32,6 @@ def json_dumps(obj, pretty=False):
         kwargs["indent"] = 4
         kwargs["sort_keys"] = True
         kwargs["separators"] = (",", ": ")
+    elif compact:
+        kwargs["separators"] = (",", ":")
     return json.dumps(obj, **kwargs)

--- a/swf/models/decision/task.py
+++ b/swf/models/decision/task.py
@@ -7,6 +7,7 @@
 
 import json
 
+from simpleflow.utils import json_dumps
 from swf.models.decision.base import Decision, decision_action
 
 
@@ -59,7 +60,7 @@ class ActivityTaskDecision(Decision):
         :param  : Specifies the name of the task list in which to schedule the activity task
         :type   :str
         """
-        input = json.dumps(input) or None
+        input = json_dumps(input) or None
 
         self.update_attributes({
             'activityId': activity_id,

--- a/swf/models/decision/workflow.py
+++ b/swf/models/decision/workflow.py
@@ -7,6 +7,7 @@
 
 import json
 
+from simpleflow.utils import json_dumps
 from swf.models.workflow import CHILD_POLICIES
 from swf.models.decision.base import Decision, decision_action
 
@@ -82,7 +83,7 @@ class WorkflowExecutionDecision(Decision):
         :param  workflow_type_version: workflow type version the execution shold belong to
         :type   workflow_type_version: str
         """
-        input = json.dumps(input) or None
+        input = json_dumps(input) or None
 
         self.update_attributes({
             'childPolicy': child_policy,
@@ -130,7 +131,7 @@ class ChildWorkflowExecutionDecision(Decision):
         :type   task_timeout: str
 
         """
-        input = json.dumps(input) or None
+        input = json_dumps(input) or None
 
         self.update_attributes({
             'childPolicy': child_policy,
@@ -195,7 +196,7 @@ class ExternalWorkflowExecutionDecision(Decision):
         :param  run_id: run id of the workflow execution to be signaled
         :type   run_id: str
         """
-        input = json.dumps(input) or None
+        input = json_dumps(input) or None
 
         self.update_attributes({
             'signalName': signal_name,

--- a/swf/models/history/builder.py
+++ b/swf/models/history/builder.py
@@ -2,6 +2,7 @@ import json
 
 import swf.models
 import swf.models.event.workflow
+from simpleflow.utils import json_dumps
 from swf.models.event.factory import EventFactory
 
 DEFAULT_DECIDER_IDENTITY = 'test_decider'
@@ -73,7 +74,7 @@ class History(swf.models.History):
                     "childPolicy": "TERMINATE",
                     "executionStartToCloseTimeout":
                         workflow.execution_timeout,
-                    "input": json.dumps(input if input else {}),
+                    "input": json_dumps(input if input else {}),
                     "workflowType": {
                         "name": workflow.name,
                         "version": workflow.version
@@ -153,7 +154,7 @@ class History(swf.models.History):
             "decisionTaskCompletedEventAttributes": {
                 "startedEventId": started,
                 "scheduledEventId": scheduled,
-                "executionContext": (json.dumps(execution_context) if
+                "executionContext": (json_dumps(execution_context) if
                                      execution_context is not None else None),
             }
         }))
@@ -214,7 +215,7 @@ class History(swf.models.History):
             "eventType": "ActivityTaskScheduled",
             "eventTimestamp": new_timestamp_string(),
             "activityTaskScheduledEventAttributes": {
-                'control': (json.dumps(control) if
+                'control': (json_dumps(control) if
                             control is not None else None),
                 "taskList": {
                     "name": activity.task_list,
@@ -230,7 +231,7 @@ class History(swf.models.History):
                                    activity.name, hash(activity.name))),
                 "scheduleToStartTimeout": activity.task_schedule_to_start_timeout,
                 "decisionTaskCompletedEventId": decision_id,
-                "input": json.dumps(input if input is not None else {}),
+                "input": json_dumps(input if input is not None else {}),
                 "startToCloseTimeout": activity.task_start_to_close_timeout,
             }
         }))
@@ -259,7 +260,7 @@ class History(swf.models.History):
             "activityTaskCompletedEventAttributes": {
                 "startedEventId": started,
                 "scheduledEventId": scheduled,
-                "result": json.dumps(result) if result is not None else None,
+                "result": json_dumps(result) if result is not None else None,
             }
         }))
 
@@ -381,12 +382,12 @@ class History(swf.models.History):
             'eventType': 'StartChildWorkflowExecutionInitiated',
             'eventTimestamp': new_timestamp_string(),
             'startChildWorkflowExecutionInitiatedEventAttributes': {
-                'control': (json.dumps(control) if
+                'control': (json_dumps(control) if
                             control is not None else None),
                 'childPolicy': 'TERMINATE',
                 'decisionTaskCompletedEventId': 76,
                 'executionStartToCloseTimeout': '432000',
-                'input': (json.dumps(input) if
+                'input': (json_dumps(input) if
                           input is not None else '{}'),
                 'tagList': tag_list,
                 'taskList': task_list,
@@ -663,7 +664,7 @@ class History(swf.models.History):
             'eventType': 'WorkflowExecutionSignaled',
             'workflowExecutionSignaledEventAttributes': {
                 'externalInitiatedEventId': external_event_id,
-                'input': json.dumps(input) if input is not None else '{}',
+                'input': json_dumps(input) if input is not None else '{}',
                 'signalName': name,
             }
         }))

--- a/swf/models/workflow.py
+++ b/swf/models/workflow.py
@@ -10,6 +10,7 @@ import json
 import collections
 
 from boto.swf.exceptions import SWFResponseError, SWFTypeAlreadyExistsError
+from simpleflow.utils import json_dumps
 
 from swf.constants import REGISTERED
 from swf.utils import immutable
@@ -255,7 +256,7 @@ class WorkflowType(BaseModel):
         workflow_id = workflow_id or '%s-%s-%i' % (self.name, self.version, time.time())
         task_list = task_list or self.task_list
         child_policy = child_policy or self.child_policy
-        input = json.dumps(input) or None
+        input = json_dumps(input) or None
         if tag_list is not None and not isinstance(tag_list, list):
             tag_list = [tag_list]
 
@@ -507,7 +508,7 @@ class WorkflowExecution(BaseModel):
             self.domain.name,
             signal_name,
             self.workflow_id,
-            input=json.dumps(input),
+            input=json_dumps(input),
             run_id=self.run_id)
 
     @exceptions.translate(SWFResponseError,

--- a/swf/utils.py
+++ b/swf/utils.py
@@ -43,6 +43,7 @@ class Enum(object):
     http://stackoverflow.com/questions/36932/whats-the-best-way-to-implement-an-enum-in-python
 
     """
+
     def __init__(self, *sequential, **named):
         self.enums = dict(zip(sequential, range(len(sequential))), **named)
 
@@ -123,6 +124,7 @@ class _CachedProperty(property):
             value = fget(obj)
             setattr(obj, self._cache_name, value)
             return value
+
         return do_fget
 
     def _wrap_fset(self, fset):
@@ -130,6 +132,7 @@ class _CachedProperty(property):
         def do_fset(obj, value):
             fset(obj, value)
             setattr(obj, self._cache_name, value)
+
         return do_fset
 
     def _wrap_fdel(self, fdel):
@@ -137,7 +140,10 @@ class _CachedProperty(property):
         def do_fdel(obj):
             fdel(obj)
             delattr(obj, self._cache_name)
+
         return do_fdel
+
+
 cached_property = _CachedProperty
 
 
@@ -153,14 +159,14 @@ def immutable(mutableclass):
         raise TypeError('@immutable: class must have __slots__')
 
     class immutableclass(mutableclass):
-        __slots__ = ()                      # No __dict__, please
+        __slots__ = ()  # No __dict__, please
 
         def __new__(cls, *args, **kw):
-            new = mutableclass(*args, **kw) # __init__ gets called while still mutable
+            new = mutableclass(*args, **kw)  # __init__ gets called while still mutable
             new.__class__ = immutableclass  # locked for writing now
             return new
 
-        def __init__(self, *args, **kw):    # Prevent re-init after __new__
+        def __init__(self, *args, **kw):  # Prevent re-init after __new__
             pass
 
     # Copy class identity:

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -1,12 +1,9 @@
 # See README for more informations about integration tests
-import os
-import unittest
 
-import boto.swf
+import simpleflow.command
 from click.testing import CliRunner
 from sure import expect
 
-import simpleflow.command
 from . import vcr, IntegrationTest
 
 

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import swf.models
-
 from simpleflow import (
     activity,
     Workflow,
@@ -10,7 +8,6 @@ from simpleflow import (
 )
 
 from .data import (
-    DOMAIN,
     DEFAULT_VERSION,
 )
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -24,6 +24,7 @@ def test_execute_program_no_kwargs():
         assert (exc_info.value.message ==
                 'command does not take keyword arguments')
 
+
 @execute.program(path='ls')
 def ls_noargs(**kwargs):
     """

--- a/tests/utils/test_json_dumps.py
+++ b/tests/utils/test_json_dumps.py
@@ -1,18 +1,21 @@
+import datetime
 import unittest
-from datetime import datetime
 
+import pytz
 from simpleflow.utils import json_dumps
 
 
 class TestJsonDumps(unittest.TestCase):
     def test_json_dumps_basics(self):
+        d = datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC)
         cases = [
-            [ None,       'null'],
-            [ 1,          '1'],
-            [ "a",        '"a"'],
-            [ [1, 2],     '[1, 2]'],
-            [ (1, 2),     '[1, 2]'],
-            [ {'a': 'b'}, '{"a": "b"}'],
+            [None,         'null'],
+            [1,            '1'],
+            ["a",          '"a"'],
+            [[1, 2],       '[1,2]'],
+            [(1, 2),       '[1,2]'],
+            [{'a': 'b'},   '{"a":"b"}'],
+            [{'start': d}, '{"start":"1970-01-01T00:00:00+00:00"}'],
         ]
         for case in cases:
             self.assertEquals(
@@ -22,6 +25,21 @@ class TestJsonDumps(unittest.TestCase):
 
     def test_json_dumps_pretty(self):
         self.assertEquals(
-                json_dumps({"abc": "def"}, pretty=True),
-                '{\n    "abc": "def"\n}',
+            json_dumps({"z": 1, "abc": "def"}, pretty=True),
+            '{\n    "abc": "def",\n    "z": 1\n}',
         )
+
+    def test_json_non_compact(self):
+        cases = [
+            [None,       'null'],
+            [1,          '1'],
+            ["a",        '"a"'],
+            [[1, 2],     '[1, 2]'],
+            [(1, 2),     '[1, 2]'],
+            [{'a': 'b'}, '{"a": "b"}'],
+        ]
+        for case in cases:
+            self.assertEquals(
+                json_dumps(case[0], compact=False),
+                case[1],
+            )


### PR DESCRIPTION
#126 

* Some tests had to be updated (e.g. idempotent activity names dependent on a hash of the JSON dumps)
* an `absolute_import` needed when running tests out of a controlled environment
* some PEP8 *au passage* as specified in CONTRIBUTING.rst :wink: 
