### PR TITLE
Don't force to pass a workflow to activity workers

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -353,15 +353,13 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
               envvar='SWF_DOMAIN',
               required=True,
               help='SWF Domain')
-@click.argument('workflow_id')
 @cli.command('worker.start', help='Start a worker process to handle activity tasks.')
-def start_worker(workflow_id, domain, task_list, log_level, nb_processes, heartbeat):
+def start_worker(domain, task_list, log_level, nb_processes, heartbeat):
     if log_level:
         logger.warning(
             "Deprecated: --log-level will be removed, use LOG_LEVEL environment variable instead"
         )
     worker.command.start(
-        workflow_id,
         domain,
         task_list,
         nb_processes,
@@ -503,7 +501,6 @@ def standalone(context,
     worker_proc = multiprocessing.Process(
         target=worker.command.start,
         args=(
-            workflow_id,
             domain,
             task_list,
         ),

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -353,15 +353,15 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
               envvar='SWF_DOMAIN',
               required=True,
               help='SWF Domain')
-@click.argument('workflow')
+@click.argument('workflow_id')
 @cli.command('worker.start', help='Start a worker process to handle activity tasks.')
-def start_worker(workflow, domain, task_list, log_level, nb_processes, heartbeat):
+def start_worker(workflow_id, domain, task_list, log_level, nb_processes, heartbeat):
     if log_level:
         logger.warning(
             "Deprecated: --log-level will be removed, use LOG_LEVEL environment variable instead"
         )
     worker.command.start(
-        workflow,
+        workflow_id,
         domain,
         task_list,
         nb_processes,
@@ -503,7 +503,7 @@ def standalone(context,
     worker_proc = multiprocessing.Process(
         target=worker.command.start,
         args=(
-            workflow,
+            workflow_id,
             domain,
             task_list,
         ),

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -18,7 +18,7 @@ from simpleflow.swf.process.actor import (
 from simpleflow.swf.task import ActivityTask
 from simpleflow.utils import json_dumps
 
-from .dispatch import from_task_registry
+from .dispatch import dynamic_dispatcher
 
 
 logger = logging.getLogger(__name__)
@@ -40,9 +40,24 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
     Polls an activity and handles it in the worker.
 
     """
-    def __init__(self, domain, task_list, workflow, heartbeat=60,
+    def __init__(self, workflow_id, domain, task_list, heartbeat=60,
                  *args, **kwargs):
-        self._workflow = workflow
+        """
+
+        :param workflow_id:
+        :type workflow_id:
+        :param domain:
+        :type domain:
+        :param task_list:
+        :type task_list:
+        :param heartbeat:
+        :type heartbeat:
+        :param args:
+        :type args:
+        :param kwargs:
+        :type kwargs:
+        """
+        self._workflow_id = workflow_id
         self.nb_retries = 3
         self._heartbeat = heartbeat
 
@@ -58,7 +73,7 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
     def name(self):
         return '{}({})'.format(
             self.__class__.__name__,
-            self._workflow._workflow.name,
+            self._workflow_id,
         )
 
     @with_state('polling')
@@ -91,16 +106,19 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
 
 
 class ActivityWorker(object):
-    def __init__(self, workflow):
-        self._dispatcher = from_task_registry.RegistryDispatcher(
-            simpleflow.registry.registry,
-            None,
-            workflow,
-        )
+    def __init__(self):
+        self._dispatcher = dynamic_dispatcher.Dispatcher()
 
     def dispatch(self, task):
+        """
+
+        :param task:
+        :type task:
+        :return:
+        :rtype:
+        """
         name = task.activity_type.name
-        return self._dispatcher.dispatch_activity(name)
+        return self._dispatcher.dispatch(name)
 
     def process(self, poller, token, task):
         logger.debug('ActivityWorker.process() pid={}'.format(os.getpid()))
@@ -128,7 +146,7 @@ class ActivityWorker(object):
 
 def process_task(poller, token, task):
     logger.debug('process_task() pid={}'.format(os.getpid()))
-    worker = ActivityWorker(poller._workflow)
+    worker = ActivityWorker()
     worker.process(poller, token, task)
 
 

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -40,12 +40,9 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
     Polls an activity and handles it in the worker.
 
     """
-    def __init__(self, workflow_id, domain, task_list, heartbeat=60,
-                 *args, **kwargs):
+    def __init__(self, domain, task_list, heartbeat=60, *args, **kwargs):
         """
 
-        :param workflow_id:
-        :type workflow_id:
         :param domain:
         :type domain:
         :param task_list:
@@ -57,7 +54,6 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
         :param kwargs:
         :type kwargs:
         """
-        self._workflow_id = workflow_id
         self.nb_retries = 3
         self._heartbeat = heartbeat
 
@@ -71,9 +67,9 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
 
     @property
     def name(self):
-        return '{}({})'.format(
+        return '{}(task_list={})'.format(
             self.__class__.__name__,
-            self._workflow_id,
+            self.task_list,
         )
 
     @with_state('polling')

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -102,8 +102,8 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
 
 
 class ActivityWorker(object):
-    def __init__(self):
-        self._dispatcher = dynamic_dispatcher.Dispatcher()
+    def __init__(self, dispatcher=None):
+        self._dispatcher = dispatcher or dynamic_dispatcher.Dispatcher()
 
     def dispatch(self, task):
         """

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -114,7 +114,7 @@ class ActivityWorker(object):
         :rtype:
         """
         name = task.activity_type.name
-        return self._dispatcher.dispatch(name)
+        return self._dispatcher.dispatch_activity(name)
 
     def process(self, poller, token, task):
         logger.debug('ActivityWorker.process() pid={}'.format(os.getpid()))

--- a/simpleflow/swf/process/worker/command.py
+++ b/simpleflow/swf/process/worker/command.py
@@ -2,25 +2,52 @@ from __future__ import absolute_import
 
 import swf.models
 
-from simpleflow.swf.process.decider import helpers
 from .base import (
     Worker,
     ActivityPoller,
 )
 
 
-def make_worker_poller(workflow, domain, task_list, heartbeat):
+def make_worker_poller(workflow_id, domain, task_list, heartbeat):
+    """
+
+    :param workflow_id:
+    :type workflow_id:
+    :param domain:
+    :type domain:
+    :param task_list:
+    :type task_list:
+    :param heartbeat:
+    :type heartbeat:
+    :return:
+    :rtype:
+    """
     domain = swf.models.Domain(domain)
     return ActivityPoller(
+        workflow_id,
         domain,
         task_list,
-        helpers.load_workflow(domain, workflow),
         heartbeat,
     )
 
 
-def start(workflow, domain, task_list, nb_processes=None, heartbeat=60):
-    poller = make_worker_poller(workflow, domain, task_list, heartbeat)
+def start(workflow_id, domain, task_list, nb_processes=None, heartbeat=60):
+    """
+
+    :param workflow_id:
+    :type workflow_id:
+    :param domain:
+    :type domain:
+    :param task_list:
+    :type task_list:
+    :param nb_processes:
+    :type nb_processes:
+    :param heartbeat:
+    :type heartbeat:
+    :return:
+    :rtype:
+    """
+    poller = make_worker_poller(workflow_id, domain, task_list, heartbeat)
     worker = Worker(poller, nb_processes)
     worker.is_alive = True
     worker.start()

--- a/simpleflow/swf/process/worker/command.py
+++ b/simpleflow/swf/process/worker/command.py
@@ -8,11 +8,9 @@ from .base import (
 )
 
 
-def make_worker_poller(workflow_id, domain, task_list, heartbeat):
+def make_worker_poller(domain, task_list, heartbeat):
     """
 
-    :param workflow_id:
-    :type workflow_id:
     :param domain:
     :type domain:
     :param task_list:
@@ -23,19 +21,12 @@ def make_worker_poller(workflow_id, domain, task_list, heartbeat):
     :rtype:
     """
     domain = swf.models.Domain(domain)
-    return ActivityPoller(
-        workflow_id,
-        domain,
-        task_list,
-        heartbeat,
-    )
+    return ActivityPoller(domain, task_list, heartbeat, heartbeat)
 
 
-def start(workflow_id, domain, task_list, nb_processes=None, heartbeat=60):
+def start(domain, task_list, nb_processes=None, heartbeat=60):
     """
 
-    :param workflow_id:
-    :type workflow_id:
     :param domain:
     :type domain:
     :param task_list:
@@ -47,7 +38,7 @@ def start(workflow_id, domain, task_list, nb_processes=None, heartbeat=60):
     :return:
     :rtype:
     """
-    poller = make_worker_poller(workflow_id, domain, task_list, heartbeat)
+    poller = make_worker_poller(domain, task_list, heartbeat)
     worker = Worker(poller, nb_processes)
     worker.is_alive = True
     worker.start()

--- a/simpleflow/swf/process/worker/dispatch/by_module.py
+++ b/simpleflow/swf/process/worker/dispatch/by_module.py
@@ -2,6 +2,9 @@ from . import exceptions
 
 
 class ModuleDispatcher(object):
+    """
+    Dispatch in a given namespace.
+    """
     def __init__(self, mod, mapping=None):
         self._module = mod
         self._mapping = mapping

--- a/simpleflow/swf/process/worker/dispatch/dynamic_dispatcher.py
+++ b/simpleflow/swf/process/worker/dispatch/dynamic_dispatcher.py
@@ -3,7 +3,18 @@ import importlib
 
 
 class Dispatcher(object):
-    def dispatch(self, name):
-        submodule_name, func_name = name.rsplit('.', 1)
-        submodule = importlib.import_module(submodule_name)
-        return getattr(submodule, func_name)
+    """
+    Dispatch by name, like simpleflow.swf.process.worker.dispatch.by_module.ModuleDispatcher
+    but without a hierarchy.
+    """
+    def dispatch_activity(self, name):
+        """
+
+        :param name:
+        :type name: str
+        :return:
+        :rtype: simpleflow.activity.Activity
+        """
+        module_name, activity_name = name.rsplit('.', 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, activity_name)

--- a/simpleflow/swf/process/worker/dispatch/dynamic_dispatcher.py
+++ b/simpleflow/swf/process/worker/dispatch/dynamic_dispatcher.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import importlib
+
+
+class Dispatcher(object):
+    def dispatch(self, name):
+        submodule_name, func_name = name.rsplit('.', 1)
+        submodule = importlib.import_module(submodule_name)
+        return getattr(submodule, func_name)

--- a/simpleflow/swf/process/worker/dispatch/from_task_registry.py
+++ b/simpleflow/swf/process/worker/dispatch/from_task_registry.py
@@ -5,16 +5,13 @@ class RegistryDispatcher(object):
     The registry has the format ``{label: {name: task}}``.
 
     """
-    def __init__(self, registry, label, workflow):
+    def __init__(self, registry, label, workflow=None):
         """
 
         :param registry: of tasks.
         :type  registry: {str: {str: Task}}
         :param label: name of the task list.
         :type  label: str.
-        :param workflow: definition.
-        :type workflow: Workflow.
-
         """
         self._registry = registry
         self._label = label


### PR DESCRIPTION
POC. This commit:

* removes the workflow from ActivityPoller
* as a consequence, don't load the workflow module (no more calling
    simpleflow.swf.process.decider.helpers.load_workflow)
* adds a generic simpleflow.swf.process.worker.dispatch.dynamic_dispatcher.Dispatcher
    that loads anything from anywhere, and use it by default instead of
    RegistryDispatcher, so the demos still work

Don't try this at home!

Signed-off-by: Yves Bastide <yves@botify.com>