### PR TITLE
Improve heartbeating

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -360,6 +360,7 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
 @click.option('--heartbeat',
               type=int,
               required=False,
+              default=60,
               help='interval in seconds')
 @click.option('--nb-processes', '-N', type=int)
 @click.option('--log-level', '-l')
@@ -398,6 +399,7 @@ def get_task_list(workflow_id=''):
 @click.option('--heartbeat',
               type=int,
               required=False,
+              default=60,
               help='Heartbeat interval in seconds.')
 @click.option('--nb-workers',
               type=int,

--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -361,7 +361,7 @@ def start_decider(workflows, domain, task_list, log_level, nb_processes):
               type=int,
               required=False,
               default=60,
-              help='interval in seconds')
+              help='Heartbeat interval in seconds (0 to disable heartbeating).')
 @click.option('--nb-processes', '-N', type=int)
 @click.option('--log-level', '-l')
 @click.option('--task-list')
@@ -400,7 +400,7 @@ def get_task_list(workflow_id=''):
               type=int,
               required=False,
               default=60,
-              help='Heartbeat interval in seconds.')
+              help='Heartbeat interval in seconds (0 to disable heartbeating).')
 @click.option('--nb-workers',
               type=int,
               required=False,

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -57,7 +57,10 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
         """
         self._workflow = workflow
         self.nb_retries = 3
-        self._heartbeat = heartbeat
+        # heartbeat=0 is a special value to disable heartbeating. We want to
+        # replace it by None because multiprocessing.Process.join() treats
+        # this as "no timeout"
+        self._heartbeat = heartbeat or None
 
         swf.actors.ActivityWorker.__init__(
             self,

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -228,7 +228,7 @@ def spawn(poller, token, task, heartbeat=60):
     :param heartbeat: heartbeat delay (seconds)
     :type heartbeat: int
     """
-    logger.debug('spawn() pid={}'.format(os.getpid()))
+    logger.debug('spawn() pid={} heartbeat={}'.format(os.getpid(), heartbeat))
     worker = multiprocessing.Process(
         target=process_task,
         args=(poller, token, task),


### PR DESCRIPTION
This PR improves heartbeating again, after #110. It's based on #135 to avoid merge conflicts later on, so please look at the last commits only. The main thing is adding a default value for the `--heartbeat` option, now activated by default. It looks minor but I fell into this trap multiple times in the last few weeks, so worth it I think.

ping @ybastide 