### PR TITLE
Add docker support for dev purposes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ nosetests.xml
 .project
 .pydevproject
 
+# Vim swap files
+*.swp
+
 # Complexity
 output/*.html
 output/*/index.html
@@ -40,3 +43,10 @@ output/*/index.html
 # Sphinx
 docs/_build
 docs/api/*
+
+# Coverage
+htmlcov/
+
+# Temporary files
+.cache/
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2.7
+MAINTAINER labs@botify.com
+
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python -
+RUN mkdir /code
+
+ADD . /code/simpleflow
+
+WORKDIR /code/simpleflow
+
+RUN python setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Development Dockerfile; see README.rst
 FROM python:2.7
 MAINTAINER labs@botify.com
 

--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,23 @@ Requirements
 - Python 3.x compatibility is NOT guaranteed for now: https://github.com/botify-labs/simpleflow/issues/87
 
 
+Development
+-----------
+
+A ``Dockerfile`` is provided to help development on non-Linux machines.
+
+You can build a ``simpleflow`` image with:
+
+    ./script/docker-build
+
+And use it with:
+
+    ./script/docker-run
+
+It will then mount your current directory inside the container and pass the
+most relevant variables (your AWS_* credentials for instance).
+
+
 Release
 -------
 

--- a/script/docker-build
+++ b/script/docker-build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t simpleflow .

--- a/script/docker-run
+++ b/script/docker-run
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+docker run -it \
+  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
+  -e LOG_LEVEL=$LOG_LEVEL \
+  -e PYTHONDONTWRITEBYTECODE=true \
+  -e SWF_DOMAIN=$SWF_DOMAIN \
+  -v $(pwd):/code/simpleflow \
+  simpleflow bash


### PR DESCRIPTION
Yesterday I ran again into OSX specific problems on python multiprocessing, which makes me want to develop (at least: test) inside a docker container from now on. OSX should still be supported by simpleflow itself, but the main target is definitely Linux.

OK for you @ybastide? Should we name files differently to make it obvious they're not there for production purposes?