### PR TITLE
Replace execution with get_execution_context

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import time
 
 from simpleflow import (
@@ -42,7 +43,8 @@ class BasicWorkflow(Workflow):
     task_list = 'example'
 
     def run(self, x, t=30):
-        print('DEBUG: workflow_id={} run_id={}'.format(self.execution.workflow_id, self.execution.run_id))
+        execution = self.get_execution_context()
+        print('DEBUG: execution context: {}'.format(execution))
         y = self.submit(increment, x)
         yy = self.submit(Delay, t, y)
         z = self.submit(double, y)

--- a/simpleflow/executor.py
+++ b/simpleflow/executor.py
@@ -143,3 +143,12 @@ class Executor(object):
     @deprecated
     def before_run(self):
         return self.before_replay()
+
+    def get_execution_context(self):
+        """
+        Get an execution context.
+        The content is specific to each executor.
+        :return: context
+        :rtype: dict
+        """
+        return {}

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -167,7 +167,7 @@ class Executor(executor.Executor):
                  force_activities=None):
         super(Executor, self).__init__(workflow)
         self._history = None
-        self._execution_context = None
+        self._execution_context = {}
         self.domain = domain
         self.task_list = task_list
         self.repair_with = repair_with
@@ -663,13 +663,16 @@ class Executor(executor.Executor):
         :type  decision_response: swf.responses.Response
         """
         execution = decision_response.execution
+        if not execution:
+            # For tests that don't provide an execution object.
+            return
+
         history = decision_response.history
         workflow_started_event = history[0]
-        # The "if execution else None" are for tests that don't provide an execution object
         self._execution_context = dict(
-            name=execution.workflow_type.name if execution else None,
-            version=execution.workflow_type.version if execution else None,
-            workflow_id=execution.workflow_id if execution else None,
-            run_id=execution.run_id if execution else None,
-            tag_list=getattr(workflow_started_event, 'tag_list', []),
+            name=execution.workflow_type.name,
+            version=execution.workflow_type.version,
+            workflow_id=execution.workflow_id,
+            run_id=execution.run_id,
+            tag_list=getattr(workflow_started_event, 'tag_list', None) or [],  # attribute is absent if no tagList
         )

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -25,7 +25,6 @@ class Workflow(object):
     tag_list = None
     child_policy = None
     execution_timeout = None
-    execution = None
 
     def __init__(self, executor):
         self._executor = executor
@@ -161,3 +160,12 @@ class Workflow(object):
         :type history: simpleflow.history.History
         """
         raise NotImplementedError
+
+    def get_execution_context(self):
+        """
+        Get an execution context from the executor.
+        The content is specific to each executor.
+        :return: context
+        :rtype: dict
+        """
+        return self.executor.get_execution_context()


### PR DESCRIPTION
Issue #174.

The new method returns a dict, containing if executed via SWF:

* name
* version
* workflow_id
* run_id
* tag_list (empty list if no tags)

Signed-off-by: Yves Bastide <yves@botify.com>