### PR TITLE
Repair reruns successful child workflows

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -24,7 +24,7 @@ from simpleflow.swf.stats import pretty
 from simpleflow.swf import helpers
 from simpleflow.swf.process import decider
 from simpleflow.swf.process import worker
-from simpleflow.swf.utils import get_workflow_history
+from simpleflow.swf.utils import get_workflow_history_and_run_id
 from simpleflow.utils import json_dumps
 from simpleflow import __version__
 
@@ -522,13 +522,14 @@ def standalone(context,
             'retrieving history of previous execution: domain={} '
             'workflow_id={} run_id={}'.format(domain, repair, repair_run_id)
         )
-        previous_history = get_workflow_history(domain, repair, run_id=repair_run_id)
+        previous_history, repair_run_id = get_workflow_history_and_run_id(domain, repair, run_id=repair_run_id)
         previous_history.parse()
         # get the previous execution input if none passed
         if not input and not input_file:
             wf_input = previous_history.events[0].input
     else:
         previous_history = None
+        repair_run_id = None
 
     task_list = create_unique_task_list(workflow_id)
     logger.info('using task list {}'.format(task_list))
@@ -544,6 +545,8 @@ def standalone(context,
             'repair_with': previous_history,
             'force_activities': force_activities,
             'is_standalone': True,
+            'repair_workflow_id': repair or None,
+            'repair_run_id': repair_run_id,
         },
     )
     decider_proc.start()

--- a/simpleflow/swf/process/decider/command.py
+++ b/simpleflow/swf/process/decider/command.py
@@ -8,7 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 def start(workflows, domain, task_list, log_level=None, nb_processes=None,
-          repair_with=None, force_activities=None, is_standalone=False):
+          repair_with=None, force_activities=None, is_standalone=False,
+          repair_workflow_id=None, repair_run_id=None,
+          ):
     """
     Start a decider.
     :param workflows:
@@ -27,6 +29,10 @@ def start(workflows, domain, task_list, log_level=None, nb_processes=None,
     :type force_activities:
     :param is_standalone: Whether the executor use this task list (and pass it to the workers)
     :type is_standalone: bool
+    :param repair_workflow_id: workflow ID to repair
+    :type repair_workflow_id: Optional[str]
+    :param repair_run_id: run ID to repair
+    :type repair_run_id: Optional[str]
     """
     if log_level:
         logger.warning(
@@ -37,6 +43,8 @@ def start(workflows, domain, task_list, log_level=None, nb_processes=None,
         repair_with=repair_with,
         force_activities=force_activities,
         is_standalone=is_standalone,
+        repair_workflow_id=repair_workflow_id,
+        repair_run_id=repair_run_id,
     )
     decider.is_alive = True
     decider.start()

--- a/simpleflow/swf/process/decider/helpers.py
+++ b/simpleflow/swf/process/decider/helpers.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def load_workflow_executor(domain, workflow_name, task_list=None, repair_with=None,
-                           force_activities=None):
+                           force_activities=None,
+                           repair_workflow_id=None, repair_run_id=None,
+                           ):
     """
     Load a workflow executor.
 
@@ -26,6 +28,10 @@ def load_workflow_executor(domain, workflow_name, task_list=None, repair_with=No
     :type repair_with: Optional[simpleflow.history.History]
     :param force_activities:
     :type force_activities: Optional[str]
+    :param repair_workflow_id: workflow ID to repair
+    :type repair_workflow_id: Optional[str]
+    :param repair_run_id: run ID to repair
+    :type repair_run_id: Optional[str]
     :return: Executor for this workflow
     :rtype: Executor
     """
@@ -39,13 +45,20 @@ def load_workflow_executor(domain, workflow_name, task_list=None, repair_with=No
     if not isinstance(domain, swf.models.Domain):
         domain = swf.models.Domain(domain)
 
-    return Executor(domain, workflow, task_list,
-                    repair_with=repair_with, force_activities=force_activities)
+    return Executor(
+        domain, workflow, task_list,
+        repair_with=repair_with,
+        force_activities=force_activities,
+        repair_workflow_id=repair_workflow_id,
+        repair_run_id=repair_run_id,
+    )
 
 
 def make_decider_poller(workflows, domain, task_list, repair_with=None,
                         force_activities=None,
-                        is_standalone=False):
+                        is_standalone=False,
+                        repair_workflow_id=None, repair_run_id=None,
+                        ):
     """
     Factory building a decider poller.
     :param workflows:
@@ -60,6 +73,10 @@ def make_decider_poller(workflows, domain, task_list, repair_with=None,
     :type force_activities: Optional[str]
     :param is_standalone: Whether the executor use this task list (and pass it to the workers)
     :type is_standalone: bool
+    :param repair_workflow_id: workflow ID to repair
+    :type repair_workflow_id: Optional[str]
+    :param repair_run_id: run ID to repair
+    :type repair_run_id: Optional[str]
     :return:
     :rtype: DeciderPoller
     """
@@ -70,9 +87,13 @@ def make_decider_poller(workflows, domain, task_list, repair_with=None,
         raise ValueError("Sorry you can't repair more than 1 workflow at once!")
 
     executors = [
-        load_workflow_executor(domain, workflow, task_list if is_standalone else None,
-                               repair_with=repair_with,
-                               force_activities=force_activities)
+        load_workflow_executor(
+            domain, workflow, task_list if is_standalone else None,
+            repair_with=repair_with,
+            force_activities=force_activities,
+            repair_workflow_id=repair_workflow_id,
+            repair_run_id=repair_run_id,
+        )
         for workflow in workflows
         ]
     domain = swf.models.Domain(domain)
@@ -81,7 +102,9 @@ def make_decider_poller(workflows, domain, task_list, repair_with=None,
 
 def make_decider(workflows, domain, task_list, nb_children=None,
                  repair_with=None, force_activities=None,
-                 is_standalone=False):
+                 is_standalone=False,
+                 repair_workflow_id=None, repair_run_id=None,
+                 ):
     """
     Instantiate a Decider.
     :param workflows:
@@ -98,6 +121,10 @@ def make_decider(workflows, domain, task_list, nb_children=None,
     :type force_activities: Optional[str]
     :param is_standalone: Whether the executor use this task list (and pass it to the workers)
     :type is_standalone: bool
+    :param repair_workflow_id: workflow ID to repair
+    :type repair_workflow_id: Optional[str]
+    :param repair_run_id: run ID to repair
+    :type repair_run_id: Optional[str]
     :return:
     :rtype: Decider
     """
@@ -105,5 +132,7 @@ def make_decider(workflows, domain, task_list, nb_children=None,
                                  repair_with=repair_with,
                                  force_activities=force_activities,
                                  is_standalone=is_standalone,
+                                 repair_workflow_id=repair_workflow_id,
+                                 repair_run_id=repair_run_id,
                                  )
     return Decider(poller, nb_children=nb_children)

--- a/simpleflow/swf/utils.py
+++ b/simpleflow/swf/utils.py
@@ -34,7 +34,7 @@ def get_workflow_execution(domain_name, workflow_id, run_id=None):
 
 # TODO: move this function inside a QuerySet object when we merge the
 # "simpleflow" and "swf" namespaces
-def get_workflow_history(domain_name, workflow_id, run_id=None):
+def get_workflow_history_and_run_id(domain_name, workflow_id, run_id=None):
     """
     Get workflow history.
     :param domain_name:
@@ -43,11 +43,12 @@ def get_workflow_history(domain_name, workflow_id, run_id=None):
     :type workflow_id: str
     :param run_id:
     :type run_id: str
-    :return:
-    :rtype: History
+    :return: History and run_id
+    :rtype: (History, str)
     """
     workflow_execution = get_workflow_execution(domain_name, workflow_id, run_id=run_id)
-    return History(workflow_execution.history())
+
+    return History(workflow_execution.history()), workflow_execution.run_id
 
 
 def sanitize_activity_context(context):


### PR DESCRIPTION
Fix issue #190:

* pass the repair workflow ID and run ID to swf.Executor in repair mode
* use them in _make_task_id

TODO: add test...

Signed-off-by: Yves Bastide <yves@botify.com>