### PR TITLE
Implement priorities on SWF tasks

### DIFF
--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -1,0 +1,75 @@
+# Simpleflow implements task priorities on SWF, see documentation here:
+# http://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html
+#
+# Unfortunately boto doesn't support priorities as of version 2.x, so it's
+# impossible for simpleflow to implement *default* priorities on SWF objects.
+# But it's still possible to schedule tasks with a given priority as this is not
+# dependent on arguments on a boto call, but rather passed as data in decisions.
+from __future__ import print_function
+
+from simpleflow import (
+    activity,
+    Workflow,
+    futures,
+)
+
+@activity.with_attributes(task_list='quickstart', version='example')
+def increment(x):
+    return x + 1
+
+
+class BaseWorkflow(Workflow):
+    version = 'example'
+    task_list = 'example'
+
+
+# EXAMPLE 1: no priority set (equivalent to "0" per the docs)
+# Command: simpleflow standalone examples.priorities.WorkflowPriority1 --input '[1]'
+class WorkflowPriority1(BaseWorkflow):
+    name = "priority-1"
+
+    def run(self, x):
+        return self.submit(increment, x).result
+
+
+# EXAMPLE 2: setting priority task by task
+# Command: simpleflow standalone examples.priorities.WorkflowPriority2 --input '[1]'
+#
+# NB: note that this doesn't really make sense when looking at a single workflow,
+# but other workflows may share the same task list with different priorities for
+# different tasks.
+class WorkflowPriority2(BaseWorkflow):
+    name = "priority-2"
+
+    def run(self, x):
+        # taskPriority will be set to "5"
+        a = self.submit(increment, x, __priority=5)
+        # no priority set
+        b = self.submit(increment, a)
+        return b.result
+
+
+# EXAMPLE 3: setting a default priority for the workflow
+# Command: simpleflow standalone examples.priorities.WorkflowPriority3 --input '[1]'
+class WorkflowPriority3(BaseWorkflow):
+    name = "priority-3"
+    task_priority = 5
+
+    def run(self, x):
+        # taskPriority will be set to "5"
+        return self.submit(increment, x).result
+
+
+# EXAMPLE 4: setting a dynamic default priority for the workflow
+# Command: simpleflow standalone examples.priorities.WorkflowPriority4 --input '[1]'
+class WorkflowPriority4(BaseWorkflow):
+    name = "priority-4"
+
+    @property
+    def task_priority(self):
+        return self._prio
+
+    def run(self, x):
+        self._prio = x
+        # taskPriority will be set to the value of "x"
+        return self.submit(increment, x).result

--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -76,13 +76,13 @@ class WorkflowPriority4(BaseWorkflow):
 # This has a higher precedence than the priority set at the workflow level, but
 # lower than a "__priority" set in self.submit().
 #
-# Setting the priority to `None` at a given point removes results in the activity
-# being scheduled without a specific priority (so it takes the default if you
+# Setting the priority to `None` at a given point results in the activity being
+# scheduled without a specific priority (so it takes the default if you
 # configured something on SWF, see the docs).
 # Setting the priority to `False` fallbacks to the next priority definition in
 # the precedence list (equivalent to NOT having it in the first place).
 @activity.with_attributes(task_list='quickstart', version='example', task_priority=12)
-def increment_prio(x):
+def increment_with_high_prio(x):
     return x + 1
 
 class WorkflowPriority5(BaseWorkflow):
@@ -91,9 +91,9 @@ class WorkflowPriority5(BaseWorkflow):
 
     def run(self, x):
         # priorty will be: 12
-        a = self.submit(increment_prio, x)
+        a = self.submit(increment_with_high_prio, x)
         # priorty will be: 13
-        b = self.submit(increment_prio, a, __priority=13)
+        b = self.submit(increment_with_high_prio, a, __priority=13)
         # priorty will not be set
-        c = self.submit(increment_prio, b, __priority=None)
+        c = self.submit(increment_with_high_prio, b, __priority=None)
         return c.result

--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -68,3 +68,32 @@ class WorkflowPriority4(BaseWorkflow):
         self._prio = x
         # taskPriority will be set to the value of "x"
         return self.submit(increment, x).result
+
+
+# EXAMPLE 5: setting a default priority via the @activity.with_attributes() decorator
+# Command: simpleflow standalone examples.priorities.WorkflowPriority5 --input '[1]'
+#
+# This has a higher precedence than the priority set at the workflow level, but
+# lower than a "__priority" set in self.submit().
+#
+# Setting the priority to `None` at a given point removes results in the activity
+# being scheduled without a specific priority (so it takes the default if you
+# configured something on SWF, see the docs).
+# Setting the priority to `False` fallbacks to the next priority definition in
+# the precedence list (equivalent to NOT having it in the first place).
+@activity.with_attributes(task_list='quickstart', version='example', task_priority=12)
+def increment_prio(x):
+    return x + 1
+
+class WorkflowPriority5(BaseWorkflow):
+    name = "priority-5"
+    task_priority = 5
+
+    def run(self, x):
+        # priorty will be: 12
+        a = self.submit(increment_prio, x)
+        # priorty will be: 13
+        b = self.submit(increment_prio, a, __priority=13)
+        # priorty will not be set
+        c = self.submit(increment_prio, b, __priority=None)
+        return c.result

--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -7,11 +7,8 @@
 # dependent on arguments on a boto call, but rather passed as data in decisions.
 from __future__ import print_function
 
-from simpleflow import (
-    activity,
-    Workflow,
-    futures,
-)
+from simpleflow import activity, Workflow
+
 
 @activity.with_attributes(task_list='quickstart', version='example')
 def increment(x):

--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -79,8 +79,11 @@ class WorkflowPriority4(BaseWorkflow):
 # Setting the priority to `None` at a given point results in the activity being
 # scheduled without a specific priority (so it takes the default if you
 # configured something on SWF, see the docs).
-# Setting the priority to `False` fallbacks to the next priority definition in
-# the precedence list (equivalent to NOT having it in the first place).
+#
+# Setting the priority to `simpleflow.activity.PRIORITY_NOT_SET` fallbacks to
+# the next priority definition in the precedence list (equivalent to NOT having
+# it in the first place). This is advanced usage and you probably don't need
+# that.
 @activity.with_attributes(task_list='quickstart', version='example', task_priority=12)
 def increment_with_high_prio(x):
     return x + 1

--- a/examples/priorities.py
+++ b/examples/priorities.py
@@ -5,8 +5,6 @@
 # impossible for simpleflow to implement *default* priorities on SWF objects.
 # But it's still possible to schedule tasks with a given priority as this is not
 # dependent on arguments on a boto call, but rather passed as data in decisions.
-from __future__ import print_function
-
 from simpleflow import activity, Workflow
 
 

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -9,6 +9,7 @@ def with_attributes(
         name=None,
         version=settings.ACTIVITY_DEFAULT_VERSION,
         task_list=settings.ACTIVITY_DEFAULT_TASK_LIST,
+        task_priority=False,
         retry=0,
         raises_on_failure=False,
         start_to_close_timeout=settings.ACTIVITY_START_TO_CLOSE_TIMEOUT,
@@ -52,6 +53,7 @@ def with_attributes(
             schedule_to_close_timeout,
             schedule_to_start_timeout,
             heartbeat_timeout,
+            task_priority=task_priority,
             idempotent=idempotent,
         )
 
@@ -69,12 +71,14 @@ class Activity(object):
                  schedule_to_close_timeout=None,
                  schedule_to_start_timeout=None,
                  heartbeat_timeout=None,
+                 task_priority=False,
                  idempotent=None):
         self._callable = callable
 
         self._name = name
         self.version = version
         self.task_list = task_list
+        self.task_priority = task_priority
         self.retry = retry
         self.raises_on_failure = raises_on_failure
         self.idempotent = idempotent

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -5,11 +5,14 @@ from . import registry
 __all__ = ['with_attributes', 'Activity']
 
 
+PRIORITY_NOT_SET = object()
+
+
 def with_attributes(
         name=None,
         version=settings.ACTIVITY_DEFAULT_VERSION,
         task_list=settings.ACTIVITY_DEFAULT_TASK_LIST,
-        task_priority=False,
+        task_priority=PRIORITY_NOT_SET,
         retry=0,
         raises_on_failure=False,
         start_to_close_timeout=settings.ACTIVITY_START_TO_CLOSE_TIMEOUT,
@@ -71,7 +74,7 @@ class Activity(object):
                  schedule_to_close_timeout=None,
                  schedule_to_start_timeout=None,
                  heartbeat_timeout=None,
-                 task_priority=False,
+                 task_priority=PRIORITY_NOT_SET,
                  idempotent=None):
         self._callable = callable
 

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -5,7 +5,11 @@ from . import registry
 __all__ = ['with_attributes', 'Activity']
 
 
-PRIORITY_NOT_SET = object()
+class NotSet(object):
+    def __repr__(self):
+        return "<Priority Not Set>"
+
+PRIORITY_NOT_SET = NotSet()
 
 
 def with_attributes(

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -17,7 +17,7 @@ from simpleflow import (
     futures,
     task,
 )
-from simpleflow.activity import Activity
+from simpleflow.activity import Activity, PRIORITY_NOT_SET
 from simpleflow.base import Submittable
 from simpleflow.history import History
 from simpleflow.swf import constants
@@ -575,13 +575,12 @@ class Executor(executor.Executor):
         Computes the correct task priority, with the following precedence (first
         is better/preferred):
         - priority set with self.submit(..., __priority=<N>)
-            (encoded as False if wasn't set)
         - priority set on the activity task decorator if any
         - priority set on the workflow execution
         - None otherwise
 
         :param priority_set_on_submit:
-        :type  priority_set_on_submit: str|int|False
+        :type  priority_set_on_submit: str|int|PRIORITY_NOT_SET
 
         :param a_task:
         :type  a_task: ActivityTask|WorkflowTask
@@ -589,12 +588,12 @@ class Executor(executor.Executor):
         :returns: the priority for this task
         :rtype: str|int|None
         """
-        if priority_set_on_submit is not False:
+        if priority_set_on_submit != PRIORITY_NOT_SET:
             return priority_set_on_submit
         elif isinstance(a_task, ActivityTask) and \
-            a_task.activity.task_priority is not False:
+            a_task.activity.task_priority != PRIORITY_NOT_SET:
             return a_task.activity.task_priority
-        elif self._workflow.task_priority is not False:
+        elif self._workflow.task_priority != PRIORITY_NOT_SET:
             return self._workflow.task_priority
         return None
 
@@ -609,7 +608,7 @@ class Executor(executor.Executor):
         # to extract it from the underlying Activity() if it's not passed to
         # self.submit() ; we DO need to pop the "__priority" kwarg though, so it
         # doesn't pollute the rest of the code.
-        priority_set_on_submit = kwargs.pop("__priority", False)
+        priority_set_on_submit = kwargs.pop("__priority", PRIORITY_NOT_SET)
 
         # casts simpleflow.task.*Task to their equivalent in simpleflow.swf.task
         if isinstance(func, BaseActivityTask):

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -457,7 +457,7 @@ class Executor(executor.Executor):
             self._idempotent_tasks_to_submit.add(task_identifier)
 
         # NB: ``decisions`` contains a single decision.
-        decisions = a_task.schedule(self.domain, task_list)
+        decisions = a_task.schedule(self.domain, task_list, priority=self.current_priority)
 
         # Check if we won't violate the 1MB limit on API requests ; if so, do NOT
         # schedule the requested task and block execution instead, with a timer
@@ -577,6 +577,8 @@ class Executor(executor.Executor):
         :type func: simpleflow.base.Submittable | Activity | Workflow
 
         """
+        self.current_priority = kwargs.pop("__priority", self._workflow.task_priority)
+
         # casts simpleflow.task.*Task to their equivalent in simpleflow.swf.task
         if isinstance(func, BaseActivityTask):
             func = ActivityTask.from_generic_task(func)

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -588,12 +588,12 @@ class Executor(executor.Executor):
         :returns: the priority for this task
         :rtype: str|int|None
         """
-        if priority_set_on_submit != PRIORITY_NOT_SET:
+        if priority_set_on_submit is not PRIORITY_NOT_SET:
             return priority_set_on_submit
         elif isinstance(a_task, ActivityTask) and \
-            a_task.activity.task_priority != PRIORITY_NOT_SET:
+            a_task.activity.task_priority is not PRIORITY_NOT_SET:
             return a_task.activity.task_priority
-        elif self._workflow.task_priority != PRIORITY_NOT_SET:
+        elif self._workflow.task_priority is not PRIORITY_NOT_SET:
             return self._workflow.task_priority
         return None
 

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -68,6 +68,7 @@ class ActivityTask(task.ActivityTask):
             'heartbeat_timeout',
             activity.task_heartbeat_timeout,
         )
+        task_priority = kwargs.get('priority')
 
         decision = swf.models.decision.ActivityTaskDecision(
             'schedule',
@@ -80,6 +81,7 @@ class ActivityTask(task.ActivityTask):
             duration_timeout=str(duration_timeout) if duration_timeout else None,
             schedule_timeout=str(schedule_timeout) if schedule_timeout else None,
             heartbeat_timeout=str(heartbeat_timeout) if heartbeat_timeout else None,
+            task_priority=task_priority,
         )
 
         return [decision]
@@ -104,7 +106,7 @@ class WorkflowTask(task.WorkflowTask):
     def task_list(self):
         return getattr(self.workflow, 'task_list', None)
 
-    def schedule(self, domain, task_list=None):
+    def schedule(self, domain, task_list=None, priority=None):
         """
         Schedule a child workflow.
 
@@ -112,6 +114,8 @@ class WorkflowTask(task.WorkflowTask):
         :type domain: swf.models.Domain
         :param task_list:
         :type task_list: Optional[str]
+        :param priority: ignored (only there for compatibility reasons with ActivityTask)
+        :type priority: Optional[str|int]
         :return:
         :rtype: list[swf.models.decision.Decision]
         """

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -23,6 +23,7 @@ class Workflow(Submittable):
     name = None
     version = None
     task_list = None
+    task_priority = None
 
     def __init__(self, executor):
         self._executor = executor

--- a/swf/models/decision/task.py
+++ b/swf/models/decision/task.py
@@ -28,7 +28,7 @@ class ActivityTaskDecision(Decision):
                  control=None, heartbeat_timeout=None,
                  input=None, duration_timeout=None,
                  schedule_timeout=None, task_timeout=None,
-                 task_list=None):
+                 task_list=None, task_priority=None):
         """Schedule activity task decision builder
 
         :param  activity_id: activity id of the activity task
@@ -58,9 +58,17 @@ class ActivityTaskDecision(Decision):
 
         :param  task_list: Specifies the name of the task list in which to schedule the activity task
         :type   :str
+
+        :param  task_priority: Specifies the numeric priority of the task to pass to SWF (defaults to None).
+        :type   task_priority: int|String
         """
         if input is not None:
             input = json_dumps(input)
+
+        if task_priority is not None:
+            # NB: here we call int() so we raise early if a wrong task priority
+            # is passed to this function.
+            task_priority = str(int(task_priority))
 
         self.update_attributes({
             'activityId': activity_id,
@@ -75,4 +83,5 @@ class ActivityTaskDecision(Decision):
             'scheduleToStartTimeout': schedule_timeout,
             'startToCloseTimeout': task_timeout,
             'taskList': {'name': task_list},
+            'taskPriority': task_priority,
         })

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,2 +1,3 @@
 from .activities import *
 from .constants import *
+from .workflows import *

--- a/tests/data/workflows.py
+++ b/tests/data/workflows.py
@@ -1,0 +1,9 @@
+from simpleflow import Workflow
+
+
+class BaseTestWorkflow(Workflow):
+    name = 'test_workflow'
+    version = 'test_version'
+    task_list = 'test_task_list'
+    decision_tasks_timeout = '300'
+    execution_timeout = '3600'

--- a/tests/test_simpleflow/swf/test_executor.py
+++ b/tests/test_simpleflow/swf/test_executor.py
@@ -1,0 +1,70 @@
+import unittest
+
+import boto
+from moto import mock_swf
+from sure import expect
+
+from simpleflow import futures
+from simpleflow.swf.executor import Executor
+from swf.actors import Decider
+from tests.data import (
+    BaseTestWorkflow,
+    DOMAIN,
+    increment,
+)
+
+
+class ExampleWorkflow(BaseTestWorkflow):
+    """
+    Example workflow definition used in tests below.
+    """
+    @property
+    def task_priority(self):
+        """
+        Sets a default task priority as a dynamic value. We could also have used
+        task_priority = <num> on the class directly.
+        """
+        return 12
+
+    def run(self):
+        a = self.submit(increment, 3)
+        b = self.submit(increment, 3, __priority=5)
+        c = self.submit(increment, 3, __priority=None)
+        futures.wait(a, b, c)
+
+
+@mock_swf
+class TestSimpleflowSwfExecutor(unittest.TestCase):
+    def setUp(self):
+        self.conn = boto.connect_swf()
+        self.conn.register_domain("TestDomain", "50")
+        self.conn.register_workflow_type(
+            "TestDomain", "test-workflow", "v1.2",
+            task_list="test-task-list", default_child_policy="TERMINATE",
+            default_execution_start_to_close_timeout="6",
+            default_task_start_to_close_timeout="3",
+        )
+        self.conn.start_workflow_execution("TestDomain", "wfe-1234",
+                                           "test-workflow", "v1.2")
+
+    def tearDown(self):
+        pass
+
+    def test_submit_resolves_priority(self):
+        response = Decider(DOMAIN, "test-task-list").poll()
+        executor = Executor(DOMAIN, ExampleWorkflow)
+        decisions, _ = executor.replay(response)
+
+        expect(decisions).to.have.length_of(3)
+
+        def get_task_priority(decision):
+            return decision["scheduleActivityTaskDecisionAttributes"].get("taskPriority")
+
+        # default priority for the whole workflow
+        expect(get_task_priority(decisions[0])).to.equal("12")
+
+        # priority passed explicitly
+        expect(get_task_priority(decisions[1])).to.equal("5")
+
+        # priority == None
+        expect(get_task_priority(decisions[2])).to.be.none

--- a/tests/test_simpleflow/test_dataflow.py
+++ b/tests/test_simpleflow/test_dataflow.py
@@ -27,6 +27,7 @@ from simpleflow.swf import constants
 from simpleflow.swf.executor import Executor
 
 from tests.data import (
+    BaseTestWorkflow,
     DOMAIN,
     double,
     increment,
@@ -37,14 +38,6 @@ from tests.data import (
     triple,
     Tetra,
 )
-
-
-class ATestWorkflow(Workflow):
-    name = 'test_workflow'
-    version = 'test_version'
-    task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
 
 
 def check_task_scheduled_decision(decision, task):
@@ -60,7 +53,7 @@ def check_task_scheduled_decision(decision, task):
     }
 
 
-class ATestDefinitionWithInput(ATestWorkflow):
+class ATestDefinitionWithInput(BaseTestWorkflow):
     """
     Execute a single task with an argument passed as the workflow's input.
     """
@@ -104,7 +97,7 @@ def test_workflow_with_input():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionThatSubmitsAnActivityTask(ATestWorkflow):
+class ATestDefinitionThatSubmitsAnActivityTask(BaseTestWorkflow):
     """
     Execute a single task already wrapped as a simpleflow.task.ActivityTask.
     """
@@ -211,7 +204,7 @@ def test_workflow_with_repair_and_force_activities():
     check_task_scheduled_decision(decisions[0], increment)
 
 
-class ATestDefinitionWithBeforeReplay(ATestWorkflow):
+class ATestDefinitionWithBeforeReplay(BaseTestWorkflow):
     """
     Execute a single task with an argument passed as the workflow's input.
     """
@@ -238,7 +231,7 @@ def test_workflow_with_before_replay():
     assert executor.workflow.a == 4
 
 
-class ATestDefinitionWithAfterReplay(ATestWorkflow):
+class ATestDefinitionWithAfterReplay(BaseTestWorkflow):
     """
     Execute a single task with an argument passed as the workflow's input.
     """
@@ -270,7 +263,7 @@ def test_workflow_with_after_replay():
     assert not hasattr(executor.workflow, 'c')
 
 
-class ATestDefinitionWithAfterClosed(ATestWorkflow):
+class ATestDefinitionWithAfterClosed(BaseTestWorkflow):
     """
     Execute a single task with an argument passed as the workflow's input.
     """
@@ -319,7 +312,7 @@ def test_workflow_with_after_closed():
     assert executor.workflow.b == 5
 
 
-class ATestDefinition(ATestWorkflow):
+class ATestDefinition(BaseTestWorkflow):
     """
     Executes two tasks. The second depends on the first.
     """
@@ -437,7 +430,7 @@ def test_workflow_with_two_tasks_not_completed():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionSameTask(ATestWorkflow):
+class ATestDefinitionSameTask(BaseTestWorkflow):
     """
     This workflow executes the same task with a different argument.
     """
@@ -502,7 +495,7 @@ def test_workflow_with_same_task_called_two_times():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionSameFuture(ATestWorkflow):
+class ATestDefinitionSameFuture(BaseTestWorkflow):
     """
     This workflow uses a single variable to hold the future of two different
     tasks.
@@ -563,7 +556,7 @@ def test_workflow_reuse_same_future():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionTwoTasksSameFuture(ATestWorkflow):
+class ATestDefinitionTwoTasksSameFuture(BaseTestWorkflow):
     """
     This test checks how the executor behaves when two tasks depends on the
     same task.
@@ -634,7 +627,7 @@ def test_workflow_with_two_tasks_same_future():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionMap(ATestWorkflow):
+class ATestDefinitionMap(BaseTestWorkflow):
     """
     This workflow only maps a task on several values, they wait for the
     availability of their result.
@@ -688,7 +681,7 @@ def test_workflow_map():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionRetryActivity(ATestWorkflow):
+class ATestDefinitionRetryActivity(BaseTestWorkflow):
     """
     This workflow executes a task that is retried on failure.
     """
@@ -794,7 +787,7 @@ def test_workflow_retry_activity_failed_again():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionChildWorkflow(ATestWorkflow):
+class ATestDefinitionChildWorkflow(BaseTestWorkflow):
     """
     This workflow executes a child workflow.
     """
@@ -840,7 +833,7 @@ def test_workflow_with_child_workflow():
         .add_child_workflow(
         workflow,
         workflow_id='workflow-test_workflow-None--0--1',
-        task_list=ATestWorkflow.task_list,
+        task_list=BaseTestWorkflow.task_list,
         input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
         result='4'
     ))
@@ -866,7 +859,7 @@ def test_workflow_with_child_workflow_failed():
         workflow,
         last_state='failed',
         workflow_id='workflow-test_workflow-None--0--1',
-        task_list=ATestWorkflow.task_list,
+        task_list=BaseTestWorkflow.task_list,
         input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
     ))
     # The child workflow fails and the executor should fail the
@@ -893,7 +886,7 @@ def test_workflow_with_child_workflow_timed_out():
         workflow,
         last_state='timed_out',
         workflow_id='workflow-test_workflow-None--0--1',
-        task_list=ATestWorkflow.task_list,
+        task_list=BaseTestWorkflow.task_list,
         input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
     ))
     # The child workflow fails and the executor should fail the
@@ -920,7 +913,7 @@ def test_workflow_with_child_workflow_canceled():
         workflow,
         last_state='canceled',
         workflow_id='workflow-test_workflow-None--0--1',
-        task_list=ATestWorkflow.task_list,
+        task_list=BaseTestWorkflow.task_list,
         input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
     ))
     # The child workflow fails and the executor should fail the
@@ -947,7 +940,7 @@ def test_workflow_with_child_workflow_terminated():
         workflow,
         last_state='terminated',
         workflow_id='workflow-test_workflow-None--0--1',
-        task_list=ATestWorkflow.task_list,
+        task_list=BaseTestWorkflow.task_list,
         input='"{\\"args\\": [1], \\"kwargs\\": {}}"',
     ))
     # The child workflow fails and the executor should fail the
@@ -962,7 +955,7 @@ def test_workflow_with_child_workflow_terminated():
     assert reason == "Cannot replay the workflow: TaskTerminated()"
 
 
-class ATestDefinitionMoreThanMaxDecisions(ATestWorkflow):
+class ATestDefinitionMoreThanMaxDecisions(BaseTestWorkflow):
     """
     This workflow executes more tasks than the maximum number of decisions a
     decider can take once.
@@ -1023,7 +1016,7 @@ def test_workflow_with_more_than_max_decisions():
     assert decisions[0] == workflow_completed
 
 
-class ATestDefinitionWithBigDecisionResponse(ATestWorkflow):
+class ATestDefinitionWithBigDecisionResponse(BaseTestWorkflow):
     """
     This workflow will schedule 2 enormous tasks so the response cannot be
     handled by SWF directly. NB: the constant is lowered to 82kB in test env,
@@ -1060,7 +1053,7 @@ class OnFailureMixin(object):
         self.failed = True
 
 
-class ATestDefinitionFailWorkflow(OnFailureMixin, ATestWorkflow):
+class ATestDefinitionFailWorkflow(OnFailureMixin, BaseTestWorkflow):
     """
     This workflow executes a single task that fails, then it explicitly fails
     the whole workflow.
@@ -1105,7 +1098,7 @@ def test_workflow_failed_from_definition():
     assert decisions[0] == workflow_failed
 
 
-class ATestDefinitionActivityRaisesOnFailure(OnFailureMixin, ATestWorkflow):
+class ATestDefinitionActivityRaisesOnFailure(OnFailureMixin, BaseTestWorkflow):
     """
     This workflow executes a task that fails and has the ``raises_on_failure``
     flag set to ``True``. It means it will raise an exception in addition to
@@ -1148,7 +1141,7 @@ def test_workflow_activity_raises_on_failure():
     assert decisions[0] == workflow_failed
 
 
-class ATestOnFailureDefinition(OnFailureMixin, ATestWorkflow):
+class ATestOnFailureDefinition(OnFailureMixin, BaseTestWorkflow):
     def run(self):
         if self.submit(raise_error).exception:
             self.fail('FAIL')
@@ -1184,7 +1177,7 @@ def test_on_failure_callback():
     assert decisions[0] == workflow_failed
 
 
-class ATestMultipleScheduledActivitiesDefinition(ATestWorkflow):
+class ATestMultipleScheduledActivitiesDefinition(BaseTestWorkflow):
     def run(self):
         a = self.submit(increment, 1)
         b = self.submit(increment, 2)
@@ -1358,7 +1351,7 @@ def test_activity_not_found_schedule_failed_already_exists():
     check_task_scheduled_decision(decisions[0], increment)
 
 
-class ATestDefinitionMoreThanMaxOpenActivities(ATestWorkflow):
+class ATestDefinitionMoreThanMaxOpenActivities(BaseTestWorkflow):
     """
     This workflow executes more tasks than the maximum number of decisions a
     decider can take once.
@@ -1500,7 +1493,7 @@ def test_more_than_1000_open_activities_partial_max():
     assert len(decisions) == 5
 
 
-class ATestTaskNaming(ATestWorkflow):
+class ATestTaskNaming(BaseTestWorkflow):
     """
     This workflow executes a few tasks and tests the naming (task ID
     assignation) depending on their idempotence.
@@ -1581,7 +1574,7 @@ def test_execution_context():
     assert expected == context
 
 
-class ATestDefinitionChildWithIdWorkflow(ATestWorkflow):
+class ATestDefinitionChildWithIdWorkflow(BaseTestWorkflow):
     name = 'test_child_workflow'
 
     @classmethod
@@ -1592,7 +1585,7 @@ class ATestDefinitionChildWithIdWorkflow(ATestWorkflow):
         return 42
 
 
-class ATestDefinitionParentWorkflow(ATestWorkflow):
+class ATestDefinitionParentWorkflow(BaseTestWorkflow):
     name = 'test_parent_workflow'
 
     def run(self):
@@ -1631,7 +1624,7 @@ def test_workflow_task_naming():
     ]
 
 
-class ATestDefinitionIdempotentChildWithIdWorkflow(ATestWorkflow):
+class ATestDefinitionIdempotentChildWithIdWorkflow(BaseTestWorkflow):
     name = 'test_child_workflow'
     idempotent = True
 
@@ -1639,7 +1632,7 @@ class ATestDefinitionIdempotentChildWithIdWorkflow(ATestWorkflow):
         return 42
 
 
-class ATestDefinitionIdempotentParentWorkflow(ATestWorkflow):
+class ATestDefinitionIdempotentParentWorkflow(BaseTestWorkflow):
     name = 'test_parent_workflow'
 
     def run(self):

--- a/tests/test_swf/models/test_decision.py
+++ b/tests/test_swf/models/test_decision.py
@@ -1,0 +1,40 @@
+import unittest
+
+from swf.models import Domain, ActivityType
+from swf.models.decision import ActivityTaskDecision
+
+
+class TestActivityTaskDecision(unittest.TestCase):
+    def setUp(self):
+        self.domain = Domain("test-domain")
+        self.activity_type = ActivityType(
+            self.domain,
+            "test-name",
+            "test-version"
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_schedule_sets_task_priority_if_present(self):
+        decision = ActivityTaskDecision()
+
+        def attributes():
+            return decision["scheduleActivityTaskDecisionAttributes"]
+
+        decision.schedule("my-activity", self.activity_type)
+        self.assertIsNone(attributes().get("taskPriority"))
+
+        decision.schedule("my-activity", self.activity_type, task_priority="0")
+        self.assertEqual(attributes().get("taskPriority"), "0")
+
+        decision.schedule("my-activity", self.activity_type, task_priority=5)
+        self.assertEqual(attributes().get("taskPriority"), "5")
+
+        decision.schedule("my-activity", self.activity_type, task_priority=-23)
+        self.assertEqual(attributes().get("taskPriority"), "-23")
+
+        for stupid_arg in ("", "not-a-number", ["list"]):
+            with self.assertRaises((ValueError, TypeError)):
+                decision.schedule("my-activity", self.activity_type,
+                                  task_priority=stupid_arg)


### PR DESCRIPTION
Issue: #34

As mentionned in #34 I thought that we needed to wait for boto 2 to have this (and possibly propose an implementation), but while discussing the need yesterday with @miloandmilo I thought that in fact we only needed to implement it at the decision level, which we fully manage.

Implementation note: I could have put the tests in "test_dataflow.py" but I wanted to try new things, especially avoid the need for building a fake history manually. Let me know what you think.

See `examples/priorities.py` for how to set priorities on a specific task, or on a workflow, possibly dynamically.

ping @ybastide @ampelmann 