### PR TITLE
Fix workers not stopping in case they start during a shutdown

### DIFF
--- a/simpleflow/process/supervisor.py
+++ b/simpleflow/process/supervisor.py
@@ -191,9 +191,6 @@ class Supervisor(NamedMixin):
         """
         Terminate all worker processes managed by this Supervisor.
         """
-        if self._terminating:
-            logger.info("process: already shutting down...")
-            return
         self._terminating = True
         logger.info(
             "process: will stop workers, this might take up several minutes. "


### PR DESCRIPTION
These days we get a lot of badly stopped workers. This is partly due to our internal usage of supervisord, but also to a concurrency issue in simpleflow: we don't re-propagate the SIGTERM once a first one has been issued, but this first one may miss processes that are already booting while we issue the SIGTERM. Better send the SIGTERM multiple times to children than having to manage this manually.

What do you think @ybastide ?