### PR TITLE
Fix UnicodeDecodeError when running `pip install .` on a windows bash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if 'publish_test' in sys.argv:
 
 
 def read(fname):
-    with open(fname) as fp:
+    with open(fname, encoding='utf8') as fp:
         content = fp.read()
     return content
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
+from io import open
 
 REQUIRES = [
 


### PR DESCRIPTION
When installling simpleflow on my windows machine, I am getting the following error.
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2100: character maps to <undefined>
```
This should fix it.