### PR TITLE
Don't send exception up if raises_on_failure false

### DIFF
--- a/examples/canvas.py
+++ b/examples/canvas.py
@@ -69,7 +69,22 @@ class CanvasWorkflow(Workflow):
             Chain(
                 (fail_incrementing, x),
                 (increment_slowly, 1),  # never executed
+                (multiply, [2]),
                 raises_on_failure=False,
+            )
+        )
+
+        futures.wait(future)
+
+        # Failing inside a chain doesn't stop a upper chain
+        future = self.submit(
+            Chain(
+                Chain(
+                    (fail_incrementing, x),
+                    raises_on_failure=False,
+                ),
+                (increment_slowly, 1),  # executed
+                (multiply, [2]),
             )
         )
 

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -155,12 +155,13 @@ class Group(object):
 
 class GroupFuture(futures.Future):
 
-    def __init__(self, activities, executor, max_parallel=None):
+    def __init__(self, activities, executor, max_parallel=None, raises_on_failure=True):
         super(GroupFuture, self).__init__()
         self.activities = activities
         self.futures = []
         self.executor = executor
         self.max_parallel = max_parallel
+        self.raises_on_failure = raises_on_failure
 
         for a in self.activities:
             if not self.max_parallel or self._count_pending_or_running < self.max_parallel:
@@ -205,8 +206,9 @@ class GroupFuture(futures.Future):
         for future in self.futures:
             if future.finished:
                 self._result.append(future.result)
-                exception = future.exception
-                exceptions.append(exception)
+                if self.raises_on_failure:
+                    exception = future.exception
+                    exceptions.append(exception)
             else:
                 self._result.append(None)
                 exceptions.append(None)
@@ -238,14 +240,16 @@ class Chain(Group):
         return ChainFuture(
             self.activities,
             executor,
-            self.send_result
+            raises_on_failure=self.raises_on_failure,
+            send_result=self.send_result,
         )
 
 
 class ChainFuture(GroupFuture):
-    def __init__(self, activities, executor, send_result=False):
+    def __init__(self, activities, executor, raises_on_failure=True, send_result=False):
         self.activities = activities
         self.executor = executor
+        self.raises_on_failure = raises_on_failure
         self._state = futures.PENDING
         self._result = None
         self._exception = None
@@ -261,6 +265,7 @@ class ChainFuture(GroupFuture):
             if not future.finished:
                 break
             if future.finished and future.exception:
+                # End this chain
                 self._has_failed = True
                 break
             previous_result = future.result

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -206,7 +206,7 @@ class GroupFuture(futures.Future):
         for future in self.futures:
             if future.finished:
                 self._result.append(future.result)
-                if self.raises_on_failure:
+                if self.raises_on_failure is not False:
                     exception = future.exception
                     exceptions.append(exception)
             else:

--- a/simpleflow/futures.py
+++ b/simpleflow/futures.py
@@ -144,7 +144,7 @@ class Future(object):
 
     def set_exception(self, exception):
         """
-        Set state to finished wiith an exception.
+        Set state to finished with an exception.
         :param exception:
         :type exception: Exception
         :return:

--- a/tests/test_simpleflow/test_canvas.py
+++ b/tests/test_simpleflow/test_canvas.py
@@ -222,6 +222,15 @@ class TestChain(unittest.TestCase):
         self.assertTrue(chain.activities[0].activity.raises_on_failure)
         self.assertTrue(chain.activities[1].activity.raises_on_failure)
 
+    def test_raises_on_failure_doesnt_set_exception(self):
+        future = Chain(
+            ActivityTask(zero_division),
+            ActivityTask(to_string, "test1"),
+            raises_on_failure=False
+        ).submit(executor)
+        self.assertEqual(1, future.count_finished_activities)
+        self.assertIsNone(future.exception)
+
 
 class TestFuncGroup(unittest.TestCase):
     def test_previous_value_with_func(self):


### PR DESCRIPTION
Issue #213: sync_result shouldn't aggregate exception if raises_on_failure is false.

Signed-off-by: Yves Bastide <yves@botify.com>