### PR TITLE
SWF: support for non-Python tasks

### DIFF
--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import inspect
+
 import hashlib
 import json
 import logging
@@ -510,9 +512,10 @@ class Executor(executor.Executor):
         :return:
         :rtype: Optional[dict]
         """
-        finder = self.TASK_TYPE_TO_EVENT_FINDER.get(type(a_task))
-        if finder:
-            return finder(self, a_task, history)
+        for typ in inspect.getmro(type(a_task)):
+            finder = self.TASK_TYPE_TO_EVENT_FINDER.get(typ)
+            if finder:
+                return finder(self, a_task, history)
         raise TypeError('invalid type {} for task {}'.format(
             type(a_task), a_task))
 

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -49,10 +49,7 @@ class ActivityTask(task.ActivityTask, SwfTask):
             version=activity.version,
         )
 
-        input = {
-            'args': self.args,
-            'kwargs': self.kwargs,
-        }
+        input = self.get_input()
 
         if task_list is None:
             task_list = activity.task_list
@@ -89,6 +86,27 @@ class ActivityTask(task.ActivityTask, SwfTask):
         )
 
         return [decision]
+
+    def get_input(self):
+        input = {
+            'args': self.args,
+            'kwargs': self.kwargs,
+        }
+        return input
+
+
+class NonPythonicActivityTask(ActivityTask):
+    """
+    ActivityTask that pass raw kwargs or args as input, without "args" and "kwargs" subkeys.
+    """
+
+    def __init__(self, activity, *args, **kwargs):
+        if args and kwargs:
+            raise ValueError("This task type doesn't support both *args and kwargs")
+        super(ActivityTask, self).__init__(activity, *args, **kwargs)
+
+    def get_input(self):
+        return self.kwargs or self.args
 
 
 class WorkflowTask(task.WorkflowTask, SwfTask):

--- a/tests/data/activities.py
+++ b/tests/data/activities.py
@@ -46,3 +46,8 @@ def raise_on_failure():
 @activity.with_attributes(version=DEFAULT_VERSION)
 def raise_error():
     raise Exception('error')
+
+
+@activity.with_attributes(version=DEFAULT_VERSION)
+def non_pythonic(*args, **kwargs):
+    pass

--- a/tests/test_simpleflow/test_dataflow.py
+++ b/tests/test_simpleflow/test_dataflow.py
@@ -15,6 +15,7 @@ import swf.models
 import swf.models.decision
 import swf.models.workflow
 from simpleflow.marker import Marker
+from simpleflow.swf.task import NonPythonicActivityTask
 from simpleflow.utils import json_dumps
 from swf.models.history import builder
 from swf.responses import Response
@@ -38,6 +39,7 @@ from tests.data import (
     raise_on_failure,
     triple,
     Tetra,
+    non_pythonic,
 )
 
 
@@ -1725,6 +1727,79 @@ def test_markers():
             'startTimerDecisionAttributes': {
                 'startToFireTimeout': '0',
                 'timerId': '_simpleflow_wake_up_timer'
+            }
+        }
+    ]
+    assert expected == decisions
+
+
+class ATestDefinitionNonPythonicWorkflow(BaseTestWorkflow):
+    def run(self, *args, **kwargs):
+        task = NonPythonicActivityTask(non_pythonic, *args, **kwargs)
+        future = self.submit(task)
+        futures.wait(future)
+
+
+@mock_swf
+def test_non_pythonic_activity_with_dict():
+    workflow = ATestDefinitionNonPythonicWorkflow
+    executor = Executor(DOMAIN, workflow)
+    args = {
+        "first_arg": 1,
+        "second_arg": {"foo": "bar"},
+    }
+    history = builder.History(workflow, input={"kwargs": args})
+    decisions, _ = executor.replay(Response(history=history, execution=None))
+    expected = [
+        {
+            'decisionType': 'ScheduleActivityTask',
+            'scheduleActivityTaskDecisionAttributes': {
+                'activityId': 'activity-tests.data.activities.non_pythonic-1',
+                'activityType': {
+                    'name': 'tests.data.activities.non_pythonic',
+                    'version': 'test'
+                },
+                'heartbeatTimeout': '300',
+                'input': json_dumps(args),
+                'scheduleToCloseTimeout': '300',
+                'scheduleToStartTimeout': '300',
+                'startToCloseTimeout': '300',
+                'taskList': {
+                    'name': 'default'
+                }
+            }
+        }
+    ]
+    assert expected == decisions
+
+
+@mock_swf
+def test_non_pythonic_activity_with_array():
+    workflow = ATestDefinitionNonPythonicWorkflow
+    executor = Executor(DOMAIN, workflow)
+    args = [
+        1,
+        {"foo": "bar"},
+    ]
+    history = builder.History(workflow, input={"args": args})
+    decisions, _ = executor.replay(Response(history=history, execution=None))
+    expected = [
+        {
+            'decisionType': 'ScheduleActivityTask',
+            'scheduleActivityTaskDecisionAttributes': {
+                'activityId': 'activity-tests.data.activities.non_pythonic-1',
+                'activityType': {
+                    'name': 'tests.data.activities.non_pythonic',
+                    'version': 'test'
+                },
+                'heartbeatTimeout': '300',
+                'input': json_dumps(args),
+                'scheduleToCloseTimeout': '300',
+                'scheduleToStartTimeout': '300',
+                'startToCloseTimeout': '300',
+                'taskList': {
+                    'name': 'default'
+                }
             }
         }
     ]


### PR DESCRIPTION
Fix #218.

* simpleflow.swf.task.ActivityTask: add a method `get_input`

* simpleflow.swf.executor.Executor#find_event: support subclasses

* simpleflow.swf.task.NonPythonicActivityTask: subclass of ActivityTask
    that passes either kwargs or args as input

* test_dataflow: add tests

Subclassing NonPythonicActivityTask from ActivityTask is debatable; this
was done to limit changes elsewhere (even there, the executor had to be
changed).

Updated: rebase, remove merged #234.

Signed-off-by: Yves Bastide <yves@botify.com>