### PR TITLE
swf/actors: support 'Message' key

### DIFF
--- a/swf/actors/core.py
+++ b/swf/actors/core.py
@@ -47,3 +47,17 @@ class Actor(ConnectedSWFObject):
         shutting down.
         """
         raise NotImplementedError
+
+    def get_error_message(self, e):
+        """
+
+        :param e:
+         :type e: boto.exception.SWFResponseError
+        :return:
+        """
+        message = e.error_message
+        if not message:
+            if e.body:
+                # Expected 'message', got 'Message' ¯\_(ツ)_/¯
+                message = e.body.get('Message')
+        return message

--- a/swf/actors/decider.py
+++ b/swf/actors/decider.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import boto.exception
 
-from swf.models.history import History
-from swf.models.workflow import WorkflowExecution, WorkflowType
 from swf.actors.core import Actor
 from swf.exceptions import PollTimeout, ResponseError, DoesNotExistError
+from swf.models.history import History
+from swf.models.workflow import WorkflowExecution, WorkflowType
 from swf.responses import Response
 
 
@@ -44,13 +44,14 @@ class Decider(Actor):
                 execution_context,
             )
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to complete decision task with token={}".format(task_token),
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
     def poll(self, task_list=None,
              identity=None,
@@ -96,13 +97,14 @@ class Decider(Actor):
                     **kwargs
                 )
             except boto.exception.SWFResponseError as e:
+                message = self.get_error_message(e)
                 if e.error_code == 'UnknownResourceFault':
                     raise DoesNotExistError(
                         "Unable to poll decision task",
-                        e.body['message'],
+                        message,
                     )
 
-                raise ResponseError(e.body['message'])
+                raise ResponseError(message)
 
             token = task.get('taskToken')
             if token is None:

--- a/swf/actors/worker.py
+++ b/swf/actors/worker.py
@@ -47,13 +47,14 @@ class ActivityWorker(Actor):
         try:
             return self.connection.respond_activity_task_canceled(task_token, details)
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to cancel activity task with token={}".format(task_token),
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
     def complete(self, task_token, result=None):
         """Responds to ``swf`` that the activity task is completed
@@ -70,13 +71,14 @@ class ActivityWorker(Actor):
                 result
             )
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to complete activity task with token={}".format(task_token),
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
     def fail(self, task_token, details=None, reason=None):
         """Replies to ``swf`` that the activity task failed
@@ -97,13 +99,14 @@ class ActivityWorker(Actor):
                 reason=format.reason(reason),
             )
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to fail activity task with token={}".format(task_token),
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
     def heartbeat(self, task_token, details=None):
         """Records activity task heartbeat
@@ -120,13 +123,14 @@ class ActivityWorker(Actor):
                 details
             )
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to send heartbeat with token={}".format(task_token),
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
     def poll(self, task_list=None, identity=None):
         """Polls for an activity task to process from current
@@ -160,13 +164,14 @@ class ActivityWorker(Actor):
                 identity=identity
             )
         except boto.exception.SWFResponseError as e:
+            message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to poll activity task",
-                    e.body['message'],
+                    message,
                 )
 
-            raise ResponseError(e.body['message'])
+            raise ResponseError(message)
 
         if 'taskToken' not in polled_activity_data:
             raise PollTimeout("Activity Worker poll timed out")


### PR DESCRIPTION
SWFResponseError can have a 'Message' key instead of 'message' in the
body: let's support that better than BotoServerError does.

(Cherry-picked from an ancient branch)

Signed-off-by: Yves Bastide <yves@botify.com>