### PR TITLE
Enhancement: get_event_details

### DIFF
--- a/simpleflow/executor.py
+++ b/simpleflow/executor.py
@@ -176,3 +176,7 @@ class Executor(object):
     @abc.abstractmethod
     def list_markers(self, all=False):
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_event_details(self, event_type, event_name):
+        raise NotImplementedError

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -453,11 +453,11 @@ class History(object):
                 'name': event.marker_name,
                 'state': event.state,
                 'details': getattr(event, 'details', None),
-                'recorded_event_id': event.id,
-                'recorded_event_timestamp': event.timestamp,
+                'event_id': event.id,
+                'timestamp': event.timestamp,
             }
             self._markers.setdefault(event.marker_name, []).append(marker)
-        elif event.state == 'failed':
+        elif event.state == 'record_failed':
             marker = {
                 'type': 'marker',
                 'name': event.marker_name,

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -153,3 +153,6 @@ class Executor(executor.Executor):
         if all:
             return [m for ml in self._markers.values() for m in ml]
         return [m[-1] for m in self._markers.values()]
+
+    def get_event_details(self, event_type, event_name):
+        return None  # To be implemented if needed

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import copy
 import hashlib
 import json
 import logging
@@ -733,8 +734,7 @@ class Executor(executor.Executor):
         """
         if priority_set_on_submit is not PRIORITY_NOT_SET:
             return priority_set_on_submit
-        elif (isinstance(a_task, ActivityTask) and
-                      a_task.activity.task_priority is not PRIORITY_NOT_SET):
+        elif isinstance(a_task, ActivityTask) and a_task.activity.task_priority is not PRIORITY_NOT_SET:
             return a_task.activity.task_priority
         elif self._workflow.task_priority is not PRIORITY_NOT_SET:
             return self._workflow.task_priority
@@ -1081,3 +1081,27 @@ class Executor(executor.Executor):
             if m['state'] == 'recorded':
                 rc.append(Marker(m['name'], json_loads_or_raw(m['details'])))
         return rc
+
+    def get_event_details(self, event_type, event_name):
+        if event_type == 'signal':
+            return self._history.signals.get(event_name)
+        elif event_type == 'marker':
+            marker_list = self._history.markers.get(event_name)
+            if not marker_list:
+                return None
+            marker_list = list(
+                filter(
+                    lambda m: m['state'] == 'recorded',
+                    marker_list
+                )
+            )
+            if not marker_list:
+                return None
+            # Make pleasing details
+            marker = copy.copy(marker_list[-1])
+            marker['details'] = json_loads_or_raw(marker['details'])
+            return marker
+        else:
+            raise ValueError('Unimplemented type {!r} for get_event_details'.format(
+                event_type
+            ))

--- a/simpleflow/swf/executor.py
+++ b/simpleflow/swf/executor.py
@@ -174,7 +174,6 @@ class Executor(executor.Executor):
             self.force_activities = re.compile(force_activities)
         else:
             self.force_activities = None
-        self.reset()
 
     # noinspection PyAttributeOutsideInit
     def reset(self):

--- a/simpleflow/utils/json_tools.py
+++ b/simpleflow/utils/json_tools.py
@@ -67,5 +67,5 @@ def json_loads_or_raw(data):
         return None
     try:
         return json.loads(data)
-    except ValueError:
+    except Exception:
         return data

--- a/simpleflow/workflow.py
+++ b/simpleflow/workflow.py
@@ -10,7 +10,8 @@ from .utils import issubclass_
 
 
 if False:
-    from typing import List, Any
+    from typing import List, Any, Optional
+    from .marker import Marker
 
 
 class Workflow(Submittable):
@@ -185,5 +186,18 @@ class Workflow(Submittable):
         return self.executor.record_marker(name, details)
 
     def list_markers(self, all=False):
-        # type: (bool) -> List[simpleflow.marker.Marker]
+        # type: (bool) -> List[Marker]
         return self.executor.list_markers(all)
+
+    def get_event_details(self, event_type, event_name):
+        # type: (str, str) -> Optional[dict]
+        """
+        Get details about an event.
+        Backend-dependent.
+        The SWF backend can handle 'marker' and 'signal' events, returning a dict
+        with name, input/details, event_id, ...
+        :param event_type:
+        :param event_name:
+        :return: backend-dependent details.
+        """
+        return self.executor.get_event_details(event_type, event_name)

--- a/swf/models/history/builder.py
+++ b/swf/models/history/builder.py
@@ -663,3 +663,16 @@ class History(swf.models.History):
         }))
 
         return self
+
+    def add_marker(self, name, details=None):
+        self.events.append(EventFactory({
+            'eventId': self.next_id,
+            'eventTimestamp': new_timestamp_string(),
+            'eventType': 'MarkerRecorded',
+            'markerRecordedEventAttributes': {
+                'details': json_dumps(details) if details is not None else '{}',
+                'markerName': name,
+            }
+        }))
+
+        return self

--- a/tests/test_simpleflow/swf/test_executor.py
+++ b/tests/test_simpleflow/swf/test_executor.py
@@ -7,6 +7,8 @@ from sure import expect
 from simpleflow import activity, futures
 from simpleflow.swf.executor import Executor
 from swf.actors import Decider
+from swf.models.history import builder
+from swf.responses import Response
 from tests.data import (
     BaseTestWorkflow,
     DOMAIN,
@@ -81,3 +83,37 @@ class TestSimpleflowSwfExecutor(unittest.TestCase):
 
         # priority set at decorator level but overridden in self.submit()
         expect(get_task_priority(decisions[4])).to.equal("30")
+
+    def test_get_event_details(self):
+        history = builder.History(ExampleWorkflow, input={})
+        signal_input = {'x': 42, 'foo': 'bar', '__propagate': False}
+        marker_details = {'baz': 'bae'}
+        history.add_signal('a_signal', signal_input)
+        history.add_marker('a_marker', marker_details)
+        executor = Executor(DOMAIN, ExampleWorkflow)
+        decisions, _ = executor.replay(Response(history=history, execution=None))
+        details = executor.get_event_details('signal', 'a_signal')
+        del details['timestamp']
+        expect(details).to.equal({
+            'type': 'signal',
+            'state': 'signaled',
+            'name': 'a_signal',
+            'input': signal_input,
+            'event_id': 4,
+            'external_initiated_event_id': 0,
+            'external_run_id': None,
+            'external_workflow_id': None,
+        })
+        details = executor.get_event_details('signal', 'another_signal')
+        expect(details).to.be.none
+        details = executor.get_event_details('marker', 'a_marker')
+        del details['timestamp']
+        expect(details).to.equal({
+            'type': 'marker',
+            'state': 'recorded',
+            'name': 'a_marker',
+            'details': marker_details,
+            'event_id': 5,
+        })
+        details = executor.get_event_details('marker', 'another_marker')
+        expect(details).to.be.none

--- a/tests/test_simpleflow/swf/test_executor.py
+++ b/tests/test_simpleflow/swf/test_executor.py
@@ -84,6 +84,8 @@ class TestSimpleflowSwfExecutor(unittest.TestCase):
         # priority set at decorator level but overridden in self.submit()
         expect(get_task_priority(decisions[4])).to.equal("30")
 
+
+class TestCaseNotNeedingDomain(unittest.TestCase):
     def test_get_event_details(self):
         history = builder.History(ExampleWorkflow, input={})
         signal_input = {'x': 42, 'foo': 'bar', '__propagate': False}

--- a/tests/test_simpleflow/test_dataflow.py
+++ b/tests/test_simpleflow/test_dataflow.py
@@ -14,7 +14,6 @@ from moto import mock_swf
 import swf.models
 import swf.models.decision
 import swf.models.workflow
-from simpleflow.marker import Marker
 from simpleflow.utils import json_dumps
 from swf.models.history import builder
 from swf.responses import Response
@@ -39,9 +38,6 @@ from tests.data import (
     triple,
     Tetra,
 )
-
-
-# Note: tests checking the Executor.workflow instance must patch `decref_workflow`.
 
 
 def check_task_scheduled_decision(decision, task):


### PR DESCRIPTION
Background: #228.
We've got a workflow which may receive pause, continue, stop, ... How to handle these?

1. One way is to not check the full history, perhaps using `previousStartedEventId`.
2. Another way is to mark processed signals, i.e. recording a marker when the signal is processed. Then we don't process anymore a signal followed by a marker (marker exists and marker['event_id'] > signal['event_id']).

To go with (2), we need to expose these event IDs: this PR does that. Of course it can have other uses too 🙂