### PR TITLE
Enhancement: 254: distinguish raises_on_failure between tasks and groups

### DIFF
--- a/examples/canvas.py
+++ b/examples/canvas.py
@@ -113,10 +113,10 @@ class CanvasWorkflow(Workflow):
                     Chain(
                         (fail_incrementing, x),
                         raises_on_failure=False,
-                        exception_on_failure=True,
+                        bubbles_exception_on_failure=True,
                     ),
                     (increment_slowly, 1),  # not executed
-                    exception_on_failure=False,
+                    bubbles_exception_on_failure=False,
                 ),
                 (multiply, [3, 2]),  # executed
             )

--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -39,13 +39,13 @@ def with_attributes(
     :param raises_on_failure: whether to raise on failuer.
     :type raises_on_failure: bool
     :param start_to_close_timeout:
-    :type start_to_close_timeout: str
+    :type start_to_close_timeout: str | int
     :param schedule_to_close_timeout:
-    :type schedule_to_close_timeout: str
+    :type schedule_to_close_timeout: str | int
     :param schedule_to_start_timeout:
-    :type schedule_to_start_timeout: str
+    :type schedule_to_start_timeout: str | int
     :param heartbeat_timeout:
-    :type heartbeat_timeout: str
+    :type heartbeat_timeout: str | int
     :param idempotent: True if the activity is idempotent.
     :type idempotent: Optional[bool]
     :rtype: () -> Activity[()]

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -115,7 +115,7 @@ class Group(SubmittableContainer):
         self.activities = []
         self.max_parallel = options.pop('max_parallel', None)
         self.raises_on_failure = options.pop('raises_on_failure', None)
-        self.exception_on_failure = options.pop('exception_on_failure', True)
+        self.bubbles_exception_on_failure = options.pop('bubbles_exception_on_failure', True)
         self.extend(activities)
 
     def append(self, submittable, *args, **kwargs):
@@ -154,7 +154,7 @@ class Group(SubmittableContainer):
         return self
 
     def submit(self, executor):
-        return GroupFuture(self.activities, executor.workflow, self.max_parallel, self.exception_on_failure)
+        return GroupFuture(self.activities, executor.workflow, self.max_parallel, self.bubbles_exception_on_failure)
 
     def __repr__(self):
         return '<{} at {:#x}, activities={!r}>'.format(self.__class__.__name__, id(self), self.activities)
@@ -162,13 +162,13 @@ class Group(SubmittableContainer):
 
 class GroupFuture(futures.Future):
 
-    def __init__(self, activities, workflow, max_parallel=None, exception_on_failure=True):
+    def __init__(self, activities, workflow, max_parallel=None, bubbles_exception_on_failure=True):
         super(GroupFuture, self).__init__()
         self.activities = activities
         self.futures = []
         self.workflow = workflow
         self.max_parallel = max_parallel
-        self.exception_on_failure = exception_on_failure
+        self.bubbles_exception_on_failure = bubbles_exception_on_failure
 
         for a in self.activities:
             if not self.max_parallel or self._count_pending_or_running < self.max_parallel:
@@ -202,7 +202,7 @@ class GroupFuture(futures.Future):
         for future in self.futures:
             if future.finished:
                 self._result.append(future.result)
-                if self.exception_on_failure is not False:
+                if self.bubbles_exception_on_failure is not False:
                     exception = future.exception
                     exceptions.append(exception)
             else:
@@ -236,15 +236,15 @@ class Chain(Group):
         self.break_on_failure = options.pop('break_on_failure', True)
         if self.send_result and not self.break_on_failure:
             raise ValueError("Cannot combine send_result=True with break_on_failure=False")
-        if options.get('raises_on_failure') is False and 'exception_on_failure' not in options:
-            options['exception_on_failure'] = False  # Compatible with 10cd67f: don't break upper chains
+        if options.get('raises_on_failure') is False and 'bubbles_exception_on_failure' not in options:
+            options['bubbles_exception_on_failure'] = False  # Compatible with 10cd67f: don't break upper chains
         super(Chain, self).__init__(*activities, **options)
 
     def submit(self, executor):
         return ChainFuture(
             self.activities,
             executor.workflow,
-            exception_on_failure=self.exception_on_failure,
+            bubbles_exception_on_failure=self.bubbles_exception_on_failure,
             send_result=self.send_result,
             break_on_failure=self.break_on_failure,
         )
@@ -253,10 +253,10 @@ class Chain(Group):
 class ChainFuture(GroupFuture):
     # Don't call GroupFuture.__init__ on purpose
     # noinspection PyMissingConstructor
-    def __init__(self, activities, workflow, exception_on_failure, send_result, break_on_failure):
+    def __init__(self, activities, workflow, bubbles_exception_on_failure, send_result, break_on_failure):
         self.activities = activities
         self.workflow = workflow
-        self.exception_on_failure = exception_on_failure
+        self.bubbles_exception_on_failure = bubbles_exception_on_failure
         self._state = futures.PENDING
         self._result = None
         self._exception = None

--- a/simpleflow/constants.py
+++ b/simpleflow/constants.py
@@ -1,3 +1,8 @@
 import os
 
 SIMPLEFLOW_ENV = os.getenv("SIMPLEFLOW_ENV", "production")
+
+# Constants useful for defining SWF timeouts
+MINUTE = 60
+HOUR = 60 * MINUTE
+DAY = 24 * HOUR

--- a/simpleflow/step/constants.py
+++ b/simpleflow/step/constants.py
@@ -1,14 +1,19 @@
-# default values for GetStepsDoneTask and MarkStepDoneTask
+"""
+Default values for GetStepsDoneTask and MarkStepDoneTask.
+"""
+
+from simpleflow.constants import HOUR, MINUTE
+
 STEP_ACTIVITY_PARAMS_DEFAULT = {
-    'schedule_to_start_timeout': 4 * 3600,
-    'start_to_close_timeout': 60,
-    'schedule_to_close_timeout': 4 * 3600 + 60,
-    'heartbeat_timeout': 180,
+    'schedule_to_start_timeout': 4 * HOUR,
+    'start_to_close_timeout': 1 * MINUTE,
+    'schedule_to_close_timeout': 4 * HOUR + MINUTE,
+    'heartbeat_timeout': 3 * MINUTE,
     'task_priority': 100,
     'version': '1.0',
     'idempotent': True,
     'raises_on_failure': True,
-    'retry': 1
+    'retry': 1,
 }
 
 UNKNOWN_CONTEXT = {

--- a/simpleflow/step/submittable.py
+++ b/simpleflow/step/submittable.py
@@ -15,14 +15,14 @@ from .utils import (
 class Step(SubmittableContainer):
 
     def __init__(self, step_name, activities, force=False, activities_if_step_already_done=None,
-                 emit_signal=False, force_steps_if_executed=None, propagate_exceptions=False):
+                 emit_signal=False, force_steps_if_executed=None, bubbles_exception_on_failure=False):
         """
         :param step_name : Name of the step
         :param force : Force the step even if already executed
         :param activities_if_step_already_done : Activities to run even step already executed
         :param emit_signal : Emit a signal when the step is executed
         :param force_steps_if_executed : list of steps names to force in the next phases of the workflow
-        :param propagate_exceptions : propagate potential exceptions to the caller
+        :param bubbles_exception_on_failure : propagate potential exceptions to the caller
         """
         self.step_name = step_name
         self.activities = activities
@@ -30,7 +30,7 @@ class Step(SubmittableContainer):
         self.activities_if_step_already_done = activities_if_step_already_done
         self.emit_signal = emit_signal
         self.force_steps_if_executed = force_steps_if_executed or []
-        self.propagate_exceptions = propagate_exceptions
+        self.bubbles_exception_on_failure = bubbles_exception_on_failure
 
     def submit(self, executor):
         workflow = executor.workflow
@@ -42,7 +42,7 @@ class Step(SubmittableContainer):
                 "forced": False,
                 "reasons": []
             }
-            chain = Chain(exception_on_failure=self.propagate_exceptions)
+            chain = Chain()
             forced_steps = workflow.get_forced_steps()
             skipped_steps = workflow.get_skipped_steps()
             if step_will_run(self.step_name, forced_steps, skipped_steps, steps_done, self.force):
@@ -85,6 +85,7 @@ class Step(SubmittableContainer):
             if self.emit_signal:
                 chain.append(
                     workflow.signal('step.{}'.format(self.step_name), propagate=False))
+            chain.bubbles_exception_on_failure = self.bubbles_exception_on_failure
             return chain
 
         return workflow.submit(Chain(

--- a/simpleflow/step/submittable.py
+++ b/simpleflow/step/submittable.py
@@ -15,13 +15,14 @@ from .utils import (
 class Step(SubmittableContainer):
 
     def __init__(self, step_name, activities, force=False, activities_if_step_already_done=None,
-                 emit_signal=False, force_steps_if_executed=None):
+                 emit_signal=False, force_steps_if_executed=None, propagate_exceptions=False):
         """
         :param step_name : Name of the step
         :param force : Force the step even if already executed
         :param activities_if_step_already_done : Activities to run even step already executed
         :param emit_signal : Emit a signal when the step is executed
         :param force_steps_if_executed : list of steps names to force in the next phases of the workflow
+        :param propagate_exceptions : propagate potential exceptions to the caller
         """
         self.step_name = step_name
         self.activities = activities
@@ -29,6 +30,7 @@ class Step(SubmittableContainer):
         self.activities_if_step_already_done = activities_if_step_already_done
         self.emit_signal = emit_signal
         self.force_steps_if_executed = force_steps_if_executed or []
+        self.propagate_exceptions = propagate_exceptions
 
     def submit(self, executor):
         workflow = executor.workflow
@@ -40,7 +42,7 @@ class Step(SubmittableContainer):
                 "forced": False,
                 "reasons": []
             }
-            chain = Chain()
+            chain = Chain(exception_on_failure=self.propagate_exceptions)
             forced_steps = workflow.get_forced_steps()
             skipped_steps = workflow.get_skipped_steps()
             if step_will_run(self.step_name, forced_steps, skipped_steps, steps_done, self.force):

--- a/tests/data/workflows.py
+++ b/tests/data/workflows.py
@@ -1,9 +1,10 @@
 from simpleflow import Workflow
+from simpleflow.constants import MINUTE, HOUR
 
 
 class BaseTestWorkflow(Workflow):
     name = 'test_workflow'
     version = 'test_version'
     task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR

--- a/tests/integration/workflow.py
+++ b/tests/integration/workflow.py
@@ -8,6 +8,7 @@ from simpleflow import (
     futures,
 )
 from simpleflow.canvas import Chain
+from simpleflow.constants import HOUR, MINUTE
 from simpleflow.task import ActivityTask
 
 
@@ -55,8 +56,8 @@ class ATestDefinitionWithIdempotentTask(Workflow):
     name = 'test_idempotent_workflow'
     version = 'example'
     task_list = 'example'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def run(self):
         results = [self.submit(get_uuid) for _ in range(10)]
@@ -72,8 +73,8 @@ class MarkerWorkflow(Workflow):
     name = 'example'
     version = 'example'
     task_list = 'example'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def run(self, use_chain):
         m1 = (self.record_marker('marker 1'))
@@ -119,8 +120,8 @@ class TestRunChild(Workflow):
     name = 'example'
     version = 'example'
     task_list = 'example'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def run(self):
         future = self.submit(ChainTestWorkflow)

--- a/tests/test_metrology.py
+++ b/tests/test_metrology.py
@@ -3,6 +3,7 @@ import unittest
 
 from simpleflow.activity import with_attributes
 from simpleflow import metrology, storage, settings
+from simpleflow.constants import MINUTE, HOUR
 from simpleflow.local.executor import Executor
 
 import boto
@@ -25,10 +26,8 @@ class MyWorkflow(metrology.MetrologyWorkflow):
     name = 'test_workflow'
     version = 'test_version'
     task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
-    tag_list = None  # FIXME should be optional
-    child_policy = None  # FIXME should be optional
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def run(self, num):
         self.submit(MyMetrologyTask, num)

--- a/tests/test_simpleflow/test_canvas.py
+++ b/tests/test_simpleflow/test_canvas.py
@@ -8,6 +8,7 @@ from simpleflow.canvas import (
     Chain,
     AggregateException,
 )
+from simpleflow.constants import HOUR, MINUTE
 from simpleflow.local.executor import Executor
 from simpleflow.activity import with_attributes
 from simpleflow.task import ActivityTask
@@ -64,8 +65,8 @@ class MyWorkflow(workflow.Workflow):
     name = 'test_workflow'
     version = 'test_version'
     task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
 
 executor = CustomExecutor(MyWorkflow)

--- a/tests/test_simpleflow/test_step.py
+++ b/tests/test_simpleflow/test_step.py
@@ -7,6 +7,7 @@ import boto
 
 from simpleflow.activity import with_attributes
 from simpleflow import workflow, task, storage, step, futures
+from simpleflow.constants import MINUTE, HOUR
 from simpleflow.step.submittable import Step
 from simpleflow.step.workflow import WorkflowStepMixin
 from simpleflow.step.tasks import GetStepsDoneTask, MarkStepDoneTask
@@ -35,8 +36,8 @@ class MyWorkflow(workflow.Workflow, WorkflowStepMixin):
     name = 'test_workflow'
     version = 'test_version'
     task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def get_activity_params(self):
         return {

--- a/tests/test_swf/test_stats.py
+++ b/tests/test_swf/test_stats.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from simpleflow.constants import HOUR, MINUTE
 from swf.models.history import builder
 
 from simpleflow import (
@@ -19,10 +20,8 @@ class ATestWorkflow(Workflow):
     name = 'test_workflow'
     version = 'test_version'
     task_list = 'test_task_list'
-    decision_tasks_timeout = '300'
-    execution_timeout = '3600'
-    tag_list = None      # FIXME should be optional
-    child_policy = None  # FIXME should be optional
+    decision_tasks_timeout = 5 * MINUTE
+    execution_timeout = 1 * HOUR
 
     def run(self, **context):
         return 0


### PR DESCRIPTION
Suggestion for fixing #254 
* add exception_on_failure
* use it (set to false) in steps, so sub-exceptions don't bubble up
* miscellaneous improvements here and there