### PR TITLE
Fix step attribute propagation

### DIFF
--- a/simpleflow/activity.py
+++ b/simpleflow/activity.py
@@ -129,3 +129,6 @@ class Activity(object):
             self.name,
             self.version,
             self.task_list)
+
+    def propagate_attribute(self, attr, val):
+        setattr(self, attr, val)

--- a/simpleflow/base.py
+++ b/simpleflow/base.py
@@ -3,7 +3,8 @@ class Submittable(object):
     Object directly submittable to an executor, without wrapping:
     E.g. an ActivityTask but not an Activity.
     """
-    pass
+    def propagate_attribute(self, attr, val):
+        pass
 
 
 class SubmittableContainer(object):
@@ -12,4 +13,5 @@ class SubmittableContainer(object):
 
     We cannot pass those objects directly to the executor
     """
-    pass
+    def propagate_attribute(self, attr, val):
+        pass

--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -109,15 +109,14 @@ class Group(SubmittableContainer):
         if isinstance(submittable, (Submittable, SubmittableContainer)):
             if args or kwargs:
                 raise ValueError('args, kwargs not supported for Submittable or SubmittableContainer')
-            if self.raises_on_failure is not None:
-                submittable.propagate_attribute('raises_on_failure', self.raises_on_failure)
-            self.activities.append(submittable)
         elif isinstance(submittable, Activity):
-            if self.raises_on_failure is not None:
-                submittable.propagate_attribute('raises_on_failure', self.raises_on_failure)
-            self.activities.append(ActivityTask(submittable, *args, **kwargs))
+            submittable = ActivityTask(submittable, *args, **kwargs)
         else:
             raise ValueError('{} should be a Submittable, Group, or Activity'.format(submittable))
+
+        if self.raises_on_failure is not None:
+            submittable.propagate_attribute('raises_on_failure', self.raises_on_failure)
+        self.activities.append(submittable)
 
     def extend(self, iterable):
         """

--- a/simpleflow/step/submittable.py
+++ b/simpleflow/step/submittable.py
@@ -92,3 +92,9 @@ class Step(SubmittableContainer):
             workflow.get_steps_done_activity(),
             FuncGroup(fn_steps_done),
             send_result=True))
+
+    def propagate_attribute(self, attr, val):
+        """
+        Propagate the attribute to the related activities.
+        """
+        self.activities.propagate_attribute(attr, val)

--- a/simpleflow/step/submittable.py
+++ b/simpleflow/step/submittable.py
@@ -18,6 +18,8 @@ class Step(SubmittableContainer):
                  emit_signal=False, force_steps_if_executed=None, bubbles_exception_on_failure=False):
         """
         :param step_name : Name of the step
+        :param activities : submittable entity, not a list.
+        :type activities : Submittable | SubmittableContainer
         :param force : Force the step even if already executed
         :param activities_if_step_already_done : Activities to run even step already executed
         :param emit_signal : Emit a signal when the step is executed

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -86,6 +86,12 @@ class ActivityTask(Task):
             method.context = self.context
             return method(*self.args, **self.kwargs)
 
+    def propagate_attribute(self, attr, val):
+        """
+        Propagate to the activity.
+        """
+        setattr(self.activity, attr, val)
+
 
 class WorkflowTask(Task):
     """
@@ -155,6 +161,12 @@ class SignalTask(Task):
     def execute(self):
         pass
 
+    def propagate_attribute(self, attr, val):
+        """
+        No propagation.
+        """
+        pass
+
 
 class MarkerTask(Task):
     def __init__(self, name, details):
@@ -180,4 +192,10 @@ class MarkerTask(Task):
         return self.args[0]
 
     def execute(self):
+        pass
+
+    def propagate_attribute(self, attr, val):
+        """
+        No propagation.
+        """
         pass

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -163,7 +163,7 @@ class SignalTask(Task):
 
     def propagate_attribute(self, attr, val):
         """
-        No propagation.
+        No propagation: We've not established a policy yet for child workflows.
         """
         pass
 
@@ -192,10 +192,4 @@ class MarkerTask(Task):
         return self.args[0]
 
     def execute(self):
-        pass
-
-    def propagate_attribute(self, attr, val):
-        """
-        No propagation.
-        """
         pass

--- a/tests/test_simpleflow/test_step.py
+++ b/tests/test_simpleflow/test_step.py
@@ -35,6 +35,11 @@ class MyTask(object):
 
 
 class CustomExecutor(Executor):
+
+    def __init__(self, workflow_class):
+        super(CustomExecutor, self).__init__(workflow_class)
+        self.create_workflow()
+
     def submit(self, func, *args, **kwargs):
         if hasattr(func, 'activity') and func.activity == MyTask:
             f = futures.Future()
@@ -67,10 +72,6 @@ class MyWorkflow(workflow.Workflow, WorkflowStepMixin):
 
     def get_step_bucket(self):
         return BUCKET
-
-executor = CustomExecutor(MyWorkflow)
-executor.initialize_history({})
-executor._workflow = MyWorkflow(executor)
 
 
 class StepTestCase(unittest.TestCase, TestWorkflowMixin):
@@ -260,6 +261,8 @@ class StepTestCase(unittest.TestCase, TestWorkflowMixin):
         Test that attribute 'raises_on_failure' is well propagated through Step.
         """
         self.create_bucket()
+        executor = CustomExecutor(MyWorkflow)
+        executor.initialize_history({})
 
         activities = Chain(
             (MyTask, 1),


### PR DESCRIPTION
The purpose of this PR is to fix attribute propagation with steps.
The buggy-case is exposed in unit test ( `propagate_attribute` doesn't handle Step case) in the file `test_step.py`.