### PR TITLE
Kill worker on UnknownResourceFault's during a heartbeat (#88)

### DIFF
--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import logging
 import multiprocessing
@@ -229,7 +230,8 @@ def spawn(poller, token, task, heartbeat=60):
                 # that the worker process is still alive.
                 os.kill(worker.pid, signal.SIGKILL)
             except OSError as e:
-                if "No such process" not in e.strerror:
+                # Compare errno to the errno for "No such process"
+                if e.errno != errno.ESRCH:
                     # re-raise if we get an OSError for another reason
                     raise
                 logger.warning('process was not here anymore, got OSError: {}'.format(e.strerror))


### PR DESCRIPTION
Note that we use SIGKILL here, which might look a bit violent for the
purpose of stopping a process (the process won't be able to cleanup
anything before dying for instance). This should probably be a SIGTERM
but we already handle SIGTERM signals today and we alias it to a
graceful shutdown. Maybe we should change this behavior, but that's a
first version.

Closes #88.