### PR TITLE
Improve process stopping

### DIFF
--- a/simpleflow/process/supervisor.py
+++ b/simpleflow/process/supervisor.py
@@ -133,6 +133,7 @@ class Supervisor(NamedMixin):
             # the supervisor process
             if self._terminating:
                 for proc in self._processes.values():
+                    logger.info("process: waiting for proces={} to finish.".format(proc))
                     proc.wait()
                 break
 


### PR DESCRIPTION
This PR aims at improving the state of #245 which still happens all the time when a supervisor has a lot of subprocesses (some private code spawn 32 workers per simpleflow supervisor).

Empirically I noticed that it fixes the last comment I made in #245 (multiple sequential SIGTERM provoking the supervisor to exit, but not all its children). I'm not sure it will fix the main issue though. We may need to wrap `self._processes` into a shared value with a lock (maybe signal handlers are editing it while being edited in the main code? which would provoke undefined behavior?), or set a flag for it to be reevaluated after SIGCHLD events (the flag would be True/False. We cannot evaluate on each loop run because that would make us iterate over all `/proc` entries every 0.1s, it would be inefficient I think.

Also I'd love to get rid of this multiprocessing at some point. Too complex to maintain :'(

@ybastide ideas welcome as usual, what do you think? poke @dauving @jordanguedj too 