### PR TITLE
Add a release script (closes #179)

### DIFF
--- a/script/release
+++ b/script/release
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import re
+import sys
+
+VERSION_FILE = "simpleflow/__init__.py"
+MAIN_BRANCH = "master"
+CHANGELOG_FILE = 'CHANGELOG.md'
+
+
+def color_msg(color, msg):
+    colors = {
+        "green": "\033[92m",
+        "yellow": "\033[93m",
+        "red": "\033[91m",
+        "blue": "\033[94m"
+    }
+    if color in colors and sys.stdout.isatty():
+        return colors[color] + msg + '\033[0m'
+    else:
+        return msg
+
+
+def step(msg):
+    print(color_msg("blue", "* {}".format(msg)))
+
+
+def fail(message):
+    """
+    :param message: message to print
+    :type message: string
+    prints a message and exits
+    """
+    sys.stderr.write(color_msg("red", "Error: {}\nExiting...\n".format(message)))
+    sys.exit(2)
+
+
+def execute(command, ignore=False, log=False):
+    """
+    :param command: command to execute
+    :type command: string
+    :param ignore: if error should be ignored
+    :type ignore: bool
+    :param log: logs commands to stdout (default: False)
+    :type log: bool
+    :return : string command output
+    Executes a command and returns the output
+    """
+    if log:
+        print("execute: {}".format(command))
+    pr = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+
+    (out, error) = pr.communicate()
+    if pr.returncode != 0 and not ignore:
+        fail("Error: executing '{}', {}".format(command, error))
+    return out
+
+
+def current_branch():
+    """
+    Returns current branch name
+    """
+    for branch in execute("git branch --no-color").split("\n"):
+        if branch.startswith("* "):
+            return branch.split()[1]
+    fail("Couldn't find current branch, please don't" \
+         " be in 'detached' state when running this.")
+
+
+def on_main_branch():
+    """
+    Checks wether we're on main branch or not. If you're not on main
+    branch, you're supposed to know what you do!
+    """
+    return current_branch() == MAIN_BRANCH
+
+
+def current_version():
+    with open(VERSION_FILE, "r") as f:
+        lines = f.readlines()
+        version_line = [line for line in lines if line.startswith("__version__")]
+        if version_line:
+            version_num = version_line[0].split()[-1]
+            version_num = version_num.replace("'", "")
+            version_num = version_num.replace('"', '')
+            if not re.search("^[0-9.]+$", version_num):
+                fail("Found version num == {}, but it looks suspicious".format(version_num))
+            return version_num
+    fail("Unable to find current version in in {}".format(VERSION_FILE))
+
+
+def increment_version(current):
+    nums = re.split("(?:\.|-)", current)
+    nums[-1] = str(int(nums[-1]) + 1)
+    return ".".join(nums)
+
+
+def generate_version_file(new_version):
+    """
+    Generates and modifies the simpleflow/__init__.py file
+    """
+    with open(VERSION_FILE, "r") as f:
+        lines = f.readlines()
+
+    def bump_version_line(line):
+        if line.startswith("__version__"):
+            return "__version__ = '{}'".format(new_version)
+        return line
+
+    lines = [bump_version_line(line) for line in lines]
+
+    with open(VERSION_FILE, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def changelog_lines(from_tag):
+    cmd = ["git", "log", "--pretty=format:- %b (%s)",
+           "--merges", "{}..".format(from_tag)]
+    out = subprocess.check_output(cmd)
+    for line in out.splitlines():
+        line = re.sub(r"\(Merge pull request (#\d+)[^)]+\)", r"(\1)", line)
+        yield line
+
+
+def proposed_changelog(from_tag, new_tag):
+    return "\n{version}\n{underline}\n\n{content}\n".format(
+        version=new_tag,
+        underline="-" * len(new_tag),
+        content="\n".join(list(changelog_lines(from_tag)))
+    )
+
+
+def write_changelog(content, new_tag):
+    with open(CHANGELOG_FILE, "r") as f:
+        current_changelog = f.readlines()
+
+    # safeguard for not documenting the same tag twice
+    if new_tag+"\n" in current_changelog:
+        fail("The tag {} is already present in {}".format(new_tag, CHANGELOG_FILE))
+
+    # detect where the first sub-title begins, it will be the first version
+    # section ; we will introduce our new changelog here
+    first_version_line_number = [
+        idx for idx, line in enumerate(current_changelog)
+        if line.startswith("---")
+    ][0] - 2
+
+    tmp_file = CHANGELOG_FILE
+    with open(tmp_file, "w") as f:
+        for idx, line in enumerate(current_changelog):
+            if idx == first_version_line_number:
+                f.write(content)
+            f.write(line)
+
+
+def generate_changelog(from_tag, to_tag):
+    proposed = proposed_changelog(from_tag, to_tag)
+    print proposed.replace("\n", "\n  ")
+    write_changelog(proposed, to_tag)
+    return proposed
+
+
+def release_tag(version_str, changes):
+    """
+    :param version_str: Version in string format
+    :type version_str: string
+    Commits and pushes the branch an tag
+    """
+    execute("git commit -a -m 'Bump version to {}'".format(version_str), log=True)
+    annotation_message = "{}\n\nChangelog:\n{}".format(version_str, changes)
+    # use "subprocess" directly to avoid escaping nightmares in annotation_message
+    subprocess.check_output(["git", "tag", "-a", version_str, "-m", annotation_message])
+    execute("git push origin HEAD", ignore=True, log=True)
+    execute("git push origin {}".format(version_str), ignore=True, log=True)
+
+
+def main(argv):
+    step("Detect current/new version")
+    current = current_version()
+    print("Current version: {}".format(current))
+
+    # decide a new version number to release
+    new_version = ""
+    default_new_version = increment_version(current)
+    while not re.match(r'^(\d+)(\.\d+){2,3}?$', new_version):
+        if new_version:
+            print("BAD FORMAT ({})! Should be in the form: 1.2.3".format(new_version))
+        new_version = raw_input("New version to release [{}]: ".format(default_new_version))
+        if not new_version:
+            new_version = default_new_version
+
+    # check if on main branch or not
+    step("Check current branch")
+    if not on_main_branch():
+        print "WARNING!"
+        print "  You're not on the main branch ({}).".format(MAIN_BRANCH)
+        print "Please confirm you want to continue [y/N] ",
+        answer = raw_input()
+        if not answer.lower().startswith("y"):
+            fail("Will not continue as you're not on the main branch")
+
+    # generate new version file
+    step("Generate version file {}".format(VERSION_FILE))
+    generate_version_file(new_version)
+
+    # generate changelog
+    step("Generate {}".format(CHANGELOG_FILE))
+    changes = generate_changelog(current, new_version)
+
+    # tag version
+    step("Release tag")
+    release_tag(new_version, changes)
+
+    # push package to pypi
+    step("Generate and push package to pypi.python.org")
+    execute("python setup.py sdist upload -r pypi", log=True)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
This PR adds a release script so we don't perform all those steps manually anymore. The script is a bit ugly (no more no less than such scripts in general ;-)) but it works correctly given you have the credentials on github and pypi.

NB1: I did NOT include building/deploying the documentation in this script ; it can certainly be done but in my case I have a different virtualenv with #284 and I don't really now how to use it automatically. I can definitely have the packages in my main simpelflow virtualenv, but another concern is that the docs update should not be mandatory for releasing simpleflow?
NB2: The PR assumes #284 is merged so it already edits CHANGELOG.md and not HISTORY.rst (only dependency as far as I know)