### PR TITLE
Add a new option (and parameter) --kill-children

### DIFF
--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -423,10 +423,16 @@ def main():
         children = process.children(recursive=True)
 
         for child in children:
-            child.terminate()
+            try:
+                child.terminate()
+            except psutil.NoSuchProcess:
+                pass
         _, still_alive = psutil.wait_procs(children, timeout=0.3)
         for child in still_alive:
-            child.kill()
+            try:
+                child.kill()
+            except psutil.NoSuchProcess:
+                pass
 
     funcname = cmd_arguments.funcname
     try:

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -426,8 +426,8 @@ def main():
 
         for child in children:
             child.terminate()
-        time.sleep(0.3)
-        for child in children:
+        _, still_alive = psutil.wait_procs(children, timeout=0.3)
+        for child in still_alive:
             child.kill()
 
     funcname = cmd_arguments.funcname

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -5,6 +5,8 @@ import sys
 
 import time
 
+import psutil
+
 try:
     import subprocess32 as subprocess
 except ImportError:
@@ -172,7 +174,7 @@ def wait_subprocess(process, timeout=None, command_info=None):
     return process.wait()
 
 
-def python(interpreter='python', logger_name=__name__, timeout=None):
+def python(interpreter='python', logger_name=__name__, timeout=None, kill_children=False):
     """
     Execute a callable as an external Python program.
 
@@ -202,6 +204,8 @@ def python(interpreter='python', logger_name=__name__, timeout=None):
                     '--result-fd={}'.format(dup_result_fd),
                     '--error-fd={}'.format(dup_error_fd),
                 ]
+                if kill_children:
+                    full_command.append('--kill-children')
                 if compat.PY2:  # close_fds doesn't work with python2 (using its C _posixsubprocess helper)
                     close_fds = False
                     pass_fds = ()
@@ -214,9 +218,7 @@ def python(interpreter='python', logger_name=__name__, timeout=None):
                     close_fds=close_fds,
                     pass_fds=pass_fds,
                 )
-
                 rc = wait_subprocess(process, timeout=timeout, command_info=full_command)
-
                 os.close(dup_result_fd)
                 os.close(dup_error_fd)
                 if rc:
@@ -409,7 +411,25 @@ def main():
         metavar='N',
         help='error file descriptor',
     )
+    parser.add_argument(
+        '--kill-children',
+        action='store_const',
+        const=True,
+        default=False,
+        help='kill child processes on exit',
+    )
     cmd_arguments = parser.parse_args()
+
+    def kill_child_processes():
+        process = psutil.Process(os.getpid())
+        children = process.children(recursive=True)
+
+        for child in children:
+            child.terminate()
+        time.sleep(0.3)
+        for child in children:
+            child.kill()
+
     funcname = cmd_arguments.funcname
     try:
         arguments = format.decode(cmd_arguments.funcargs)
@@ -447,6 +467,8 @@ def main():
         if not compat.PY2:
             details = details.encode('utf-8')
         os.write(cmd_arguments.error_fd, details)
+        if cmd_arguments.kill_children:
+            kill_child_processes()
         sys.exit(1)
 
     if cmd_arguments.result_fd == 1:  # stdout (legacy)
@@ -456,6 +478,8 @@ def main():
     if not compat.PY2:
         result = result.encode('utf-8')
     os.write(cmd_arguments.result_fd, result)
+    if cmd_arguments.kill_children:
+        kill_child_processes()
 
 
 if __name__ == '__main__':

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -413,9 +413,7 @@ def main():
     )
     parser.add_argument(
         '--kill-children',
-        action='store_const',
-        const=True,
-        default=False,
+        action='store_true',
         help='kill child processes on exit',
     )
     cmd_arguments = parser.parse_args()

--- a/tests/test_simpleflow/test_execute.py
+++ b/tests/test_simpleflow/test_execute.py
@@ -293,19 +293,19 @@ def test_timeout_execute_from_thread():
     t.join()
 
 
-def create_subprocess_and_raise():
+def create_sleeper_subprocess():
     pid = subprocess.Popen(['sleep', '600']).pid
     return pid
 
 
 def test_execute_dont_kill_children():
-    pid = execute.python()(create_subprocess_and_raise)()
+    pid = execute.python()(create_sleeper_subprocess)()
     subprocess = psutil.Process(pid)
     assert subprocess.status() == 'sleeping'
     subprocess.terminate()  # cleanup
 
 
 def test_execute_kill_children():
-    pid = execute.python(kill_children=True)(create_subprocess_and_raise)()
+    pid = execute.python(kill_children=True)(create_sleeper_subprocess)()
     with pytest.raises(psutil.NoSuchProcess):
         psutil.Process(pid)

--- a/tests/test_simpleflow/test_execute.py
+++ b/tests/test_simpleflow/test_execute.py
@@ -15,7 +15,6 @@ import subprocess
 
 from simpleflow import execute
 from simpleflow.exceptions import ExecutionError, ExecutionTimeoutError
-from simpleflow.execute import get_name
 
 
 @execute.program(path='ls')

--- a/tests/test_simpleflow/test_execute.py
+++ b/tests/test_simpleflow/test_execute.py
@@ -7,11 +7,15 @@ import os.path
 import platform
 import threading
 
+import psutil
 import pytest
 import time
 
+import subprocess
+
 from simpleflow import execute
 from simpleflow.exceptions import ExecutionError, ExecutionTimeoutError
+from simpleflow.execute import get_name
 
 
 @execute.program(path='ls')
@@ -287,3 +291,21 @@ def test_timeout_execute_from_thread():
     t = threading.Thread(target=test_timeout_execute)
     t.start()
     t.join()
+
+
+def create_subprocess_and_raise():
+    pid = subprocess.Popen(['sleep', '600']).pid
+    return pid
+
+
+def test_execute_dont_kill_children():
+    pid = execute.python()(create_subprocess_and_raise)()
+    subprocess = psutil.Process(pid)
+    assert subprocess.status() == 'sleeping'
+    subprocess.terminate()  # cleanup
+
+
+def test_execute_kill_children():
+    pid = execute.python(kill_children=True)(create_subprocess_and_raise)()
+    with pytest.raises(psutil.NoSuchProcess):
+        psutil.Process(pid)


### PR DESCRIPTION
This option forces simpleflow to kill child processes in simpleflow.execute, on exit.

Note: I wasn't be able to use `atexit` correctly (at least with Pypy).

Related issue: https://github.com/botify-labs/simpleflow/issues/291