### PR TITLE
Don't raise when ThrottlingException occur on RecordActivityTaskHeartbeat endpoint

### DIFF
--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -260,6 +260,14 @@ def spawn(poller, token, task, heartbeat=60):
                     raise
                 logger.warning('process was not here anymore, got OSError: {}'.format(e.strerror))
             return
+        except swf.exceptions.RateLimitExceededError as error:
+            # ignore rate limit errors: high chances the next heartbeat will be
+            # ok anyway, so it would be stupid to break the task for that
+            logger.warning(
+                'got a "ThrottlingException / Rate exceeded" when heartbeating for task {}: {}'.format(
+                    task.activity_type.name,
+                    error))
+            continue
         except Exception as error:
             # Let's crash if it cannot notify the heartbeat failed.  The
             # subprocess will become orphan and the heartbeat timeout may

--- a/swf/actors/worker.py
+++ b/swf/actors/worker.py
@@ -3,7 +3,7 @@
 import boto.exception
 from swf.actors import Actor
 from swf.models import ActivityTask
-from swf.exceptions import PollTimeout, ResponseError, DoesNotExistError
+from swf.exceptions import PollTimeout, ResponseError, DoesNotExistError, RateLimitExceededError
 from swf import format
 
 
@@ -130,6 +130,12 @@ class ActivityWorker(Actor):
             if e.error_code == 'UnknownResourceFault':
                 raise DoesNotExistError(
                     "Unable to send heartbeat with token={}".format(task_token),
+                    message,
+                )
+
+            if e.error_code == 'ThrottlingException':
+                raise RateLimitExceededError(
+                    "Rate exceeded when sending heartbeat with token={}".format(task_token),
                     message,
                 )
 

--- a/swf/exceptions.py
+++ b/swf/exceptions.py
@@ -112,6 +112,10 @@ class InvalidKeywordArgumentError(SWFError):
     pass
 
 
+class RateLimitExceededError(SWFError):
+    pass
+
+
 def ignore(*args, **kwargs):
     return
 


### PR DESCRIPTION
This PR corresponds to an ongoing incident on the botify platform, so I merge it directly but reviews a posteriori are welcome. This can certainly be improved and extended to other SWF API calls I guess.