### PR TITLE
Fix diskcache OperationalError

### DIFF
--- a/swf/format.py
+++ b/swf/format.py
@@ -106,11 +106,16 @@ def _pull_jumbo_field(location):
     except OperationalError:
         logger.warning("diskcache: got an OperationalError, skipping cache usage")
         pass
+
     content = storage.pull_content(bucket, path)
 
     if cache:
-        logger.debug("diskcache: setting key={} on cache_dir={}".format(cache_key, constants.CACHE_DIR))
-        cache.set(cache_key, content, expire=3 * HOUR)
+        try:
+            logger.debug("diskcache: setting key={} on cache_dir={}".format(cache_key, constants.CACHE_DIR))
+            cache.set(cache_key, content, expire=3 * HOUR)
+        except OperationalError:
+            logger.warning("diskcache: got an OperationalError on write, skipping cache write")
+            pass
 
     return content
 

--- a/swf/format.py
+++ b/swf/format.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from diskcache import Cache
 import lazy_object_proxy
+from sqlite3 import OperationalError
 
 from . import constants
 from .core import logger
@@ -94,14 +95,22 @@ def _pull_jumbo_field(location):
     # not that useful. The performance hit should be minimal. To be improved later.
     # NB2: cache has to be lazily instantiated here, cache objects do not survive forks,
     # see DiskCache docs.
-    cache = Cache(constants.CACHE_DIR)
-    cache_key = "jumbo_fields/" + path.split("/")[-1]
-    if cache_key in cache:
-        logger.debug("diskcache: getting key={} from cache_dir={}".format(cache_key, constants.CACHE_DIR))
-        return cache[cache_key]
+    cache = None
+
+    try:
+        cache = Cache(constants.CACHE_DIR)
+        cache_key = "jumbo_fields/" + path.split("/")[-1]
+        if cache_key in cache:
+            logger.debug("diskcache: getting key={} from cache_dir={}".format(cache_key, constants.CACHE_DIR))
+            return cache[cache_key]
+    except OperationalError:
+        logger.warning("diskcache: got an OperationalError, skipping cache usage")
+        pass
     content = storage.pull_content(bucket, path)
-    logger.debug("diskcache: setting key={} on cache_dir={}".format(cache_key, constants.CACHE_DIR))
-    cache.set(cache_key, content, expire=3 * HOUR)
+
+    if cache:
+        logger.debug("diskcache: setting key={} on cache_dir={}".format(cache_key, constants.CACHE_DIR))
+        cache.set(cache_key, content, expire=3 * HOUR)
 
     return content
 

--- a/swf/format.py
+++ b/swf/format.py
@@ -105,7 +105,6 @@ def _pull_jumbo_field(location):
             return cache[cache_key]
     except OperationalError:
         logger.warning("diskcache: got an OperationalError, skipping cache usage")
-        pass
 
     content = storage.pull_content(bucket, path)
 
@@ -115,7 +114,6 @@ def _pull_jumbo_field(location):
             cache.set(cache_key, content, expire=3 * HOUR)
         except OperationalError:
             logger.warning("diskcache: got an OperationalError on write, skipping cache write")
-            pass
 
     return content
 


### PR DESCRIPTION
This PR adds try/except around disk cache usages so we don't get `sqlite3.OperationalError`s anymore when using it. This cache is only used for jumbo fields as of now, so no need to abstract it elsewhere in my opinion. Obviously this is at the expense of a few more S3 calls, but not a big deal given the failure rate we experienced so far.

Their documentation documents the `diskcache.FanoutCache` to be a better, sharded alternative to a simple `diskcache.Cache`: http://www.grantjenks.com/docs/diskcache/tutorial.html#tutorial-fanoutcache ; but when reading the code, a `FanoutCache` _does_ instantiate all `Cache`s when being instantiated itself. I guess our use case is not documented because we lazily instantiate many `Cache` objects (one on every new decision) which may not be common for the project.

What do you think @ybastide @benjastudio ?