### PR TITLE
Remove raise when get_workflow_id is set and idempotent is true.

### DIFF
--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -118,8 +118,6 @@ class WorkflowTask(Task):
         self.kwargs = self.resolve_kwargs(**kwargs)
 
         if get_workflow_id:
-            if self.idempotent:
-                raise Exception('"get_workflow_id" and "idempotent" are mutually exclusive')
             self.id = get_workflow_id(workflow, *self.args, **self.kwargs)
         else:
             self.id = None


### PR DESCRIPTION
It is currently impossible to give a custom id to a childworkflow and at the same time use the idempotency property.

Currently the workflow id is not used to avoid relaunching a (workflow-)task.
Instead the idempotent attribute is used:
https://github.com/botify-labs/simpleflow/blob/53205fee671ba4ff02d46b1895b36fabf3c4b95a/simpleflow/swf/executor.py#L658-L665


So, in order to be able to give a custom workflow id to a childworkflow and at the same time uses the idempotency, the following `raise` need to be removed:
https://github.com/botify-labs/simpleflow/blob/53205fee671ba4ff02d46b1895b36fabf3c4b95a/simpleflow/task.py#L120-L125