### PR TITLE
add meta to metrology, upload stats only at the end of a task

### DIFF
--- a/simpleflow/command.py
+++ b/simpleflow/command.py
@@ -690,5 +690,8 @@ def activity_rerun(domain,
     logger.info("Will re-run: {}(*{}, **{})".format(task, args, kwargs))
 
     # execute the activity task with the correct arguments
-    result = ActivityTask(task, *args, **kwargs).execute()
+    instance = ActivityTask(task, *args, **kwargs)
+    result = instance.execute()
+    if hasattr(instance, 'post_execute'):
+        instance.post_execute()
     logger.info("Result (JSON): {}".format(json_dumps(result, compact=False)))

--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -463,6 +463,8 @@ def main():
             inst = callable_(*args, **kwargs)
             inst.context = context
             result = inst.execute()
+            if hasattr(inst, 'post_execute'):
+                inst.post_execute()
         else:
             callable_.context = context
             result = callable_(*args, **kwargs)

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -87,6 +87,8 @@ class Executor(executor.Executor):
 
         try:
             future._result = task.execute()
+            if hasattr(task, 'post_execute'):
+                task.post_execute()
             state = 'completed'
         except Exception as err:
             future._exception = err

--- a/simpleflow/metrology.py
+++ b/simpleflow/metrology.py
@@ -116,7 +116,7 @@ class MetrologyTask(object):
 
         content = {"steps": [], "meta": getattr(self, 'meta', None)}
 
-        for step in self.steps:
+        for step in getattr(self, 'steps', []):
             content["steps"].append(step.get_stats())
 
         storage.push_content(

--- a/simpleflow/metrology.py
+++ b/simpleflow/metrology.py
@@ -130,7 +130,7 @@ class MetrologyTask(object):
         pass
 
     def post_execute(self):
-        return self.upload_stats()
+        self.upload_stats()
 
 
 class MetrologyWorkflow(Workflow):

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -84,7 +84,10 @@ class ActivityTask(Task):
         if hasattr(method, 'execute'):
             task = method(*self.args, **self.kwargs)
             task.context = self.context
-            return task.execute()
+            result = task.execute()
+            if hasattr(task, 'post_execute'):
+                task.post_execute()
+            return result
         else:
             # NB: the following line attaches some *state* to the callable, so it
             # can be used directly for advanced usage. This works well because we

--- a/tests/test_metrology.py
+++ b/tests/test_metrology.py
@@ -20,6 +20,7 @@ class MyMetrologyTask(metrology.MetrologyTask):
         with self.step('Step1') as step:
             step.metadata["num"] = self.num
             step.read.records = self.num
+        self.meta = "foo bar"
 
 
 class MyWorkflow(metrology.MetrologyWorkflow):
@@ -47,16 +48,19 @@ class MetrologyTestCase(unittest.TestCase):
         res = json.loads(storage.pull_content(
             settings.METROLOGY_BUCKET,
             "local/local/activity.0.json"))
-        self.assertEquals(res[0]["name"], "Step1")
-        self.assertEquals(res[0]["read"]["records"], 1)
-        self.assertEquals(res[0]["metadata"]["num"], 1)
+        self.assertEquals(res["meta"], "foo bar")
+        steps = res["steps"]
+        self.assertEquals(steps[0]["name"], "Step1")
+        self.assertEquals(steps[0]["read"]["records"], 1)
+        self.assertEquals(steps[0]["metadata"]["num"], 1)
 
         res = json.loads(storage.pull_content(
             settings.METROLOGY_BUCKET,
             "local/local/metrology.json"))
-        self.assertEquals(res[0][1]["metrology"][0]["name"], "Step1")
-        self.assertEquals(res[0][1]["metrology"][0]["read"]["records"], 1)
-        self.assertEquals(res[0][1]["metrology"][0]["metadata"]["num"], 1)
+        self.assertEquals(res[0][1]["metrology"]["meta"], "foo bar")
+        self.assertEquals(res[0][1]["metrology"]["steps"][0]["name"], "Step1")
+        self.assertEquals(res[0][1]["metrology"]["steps"][0]["read"]["records"], 1)
+        self.assertEquals(res[0][1]["metrology"]["steps"][0]["metadata"]["num"], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Refactor metrology to inject metadata in addition to steps (your own metrology ?)
* Add `post_execute` to Task objects

Please review @jbbarth @ybastide 
