### PR TITLE
Fixed issue #293 by adding a minimum 1 second delay

### DIFF
--- a/simpleflow/utils/retry.py
+++ b/simpleflow/utils/retry.py
@@ -21,9 +21,12 @@ def constant(value):
 
 
 def exponential(value):
+    """
+    Set retry time exponentially; per the "+ 1," begin at a minimum of one second.
+    """
     import random
 
-    return random.random() * (2 ** value) + 1;
+    return random.random() * (2 ** value) + 1
 
 def with_delay(
         nb_times=1,

--- a/simpleflow/utils/retry.py
+++ b/simpleflow/utils/retry.py
@@ -23,8 +23,7 @@ def constant(value):
 def exponential(value):
     import random
 
-    return random.random() * (2 ** value)
-
+    return random.random() * (2 ** value) + 1;
 
 def with_delay(
         nb_times=1,


### PR DESCRIPTION
Although this may be wildly out of date, fixed [this issue](https://github.com/botify-labs/simpleflow/issues/293) by adding a minimum delay of a single second to the calculated delay.
(I'm fairly new to contributing so any feedback is appreciated! I didn't create a new branch, as this wasn't a major feature implementation on my part, but I can do so if necessary)