### PR TITLE
simpleflow.execute.python: handle huge args

### DIFF
--- a/simpleflow/execute.py
+++ b/simpleflow/execute.py
@@ -115,10 +115,7 @@ def format_arguments_json(*args, **kwargs):
         'args': args,
         'kwargs': kwargs,
     })
-    try:
-        return format.encode(dump, MAX_ARGUMENTS_JSON_LENGTH)
-    except format.JumboTooLargeError:
-        return dump
+    return dump
 
 
 def get_name(func):
@@ -214,7 +211,6 @@ def python(interpreter='python', logger_name=__name__, timeout=None, kill_childr
                     '--context={}'.format(json_dumps(context)),
                 ]
                 if len(arguments_json) < MAX_ARGUMENTS_JSON_LENGTH:  # command-line limit on Linux: 128K
-                    # Note: on production systems, format_arguments_json should be able to use Jumbo fields
                     full_command.append(arguments_json)
                     arg_file = None
                     arg_fd = None
@@ -479,9 +475,8 @@ def main():
             parser.error('the following arguments are required: funcargs')
     else:
         with os.fdopen(cmd_arguments.arguments_json_fd) as arguments_json_file:
-            content = arguments_json_file.read()#.decode('utf-8')
+            content = arguments_json_file.read()
     try:
-        print("content: {}".format(content))
         arguments = format.decode(content)
     except Exception:
         raise ValueError('cannot load arguments from {}'.format(

--- a/tests/test_simpleflow/test_execute.py
+++ b/tests/test_simpleflow/test_execute.py
@@ -309,3 +309,13 @@ def test_execute_kill_children():
     pid = execute.python(kill_children=True)(create_sleeper_subprocess)()
     with pytest.raises(psutil.NoSuchProcess):
         psutil.Process(pid)
+
+
+@execute.python()
+def length(x):
+    return len(x)
+
+
+def test_large_command_line():
+    x = "a" * 1024 * 1024
+    assert length(x) == len(x)


### PR DESCRIPTION
* format_arguments_json: use format.encode
* if this fails (e.g. no Jumbo bucket defined), use a local file

Signed-off-by: Yves Bastide <yves@botify.com>