### PR TITLE
Remove explicit handling of AWS credentials from env vars.

### DIFF
--- a/docs/src/features/swf_layer.md
+++ b/docs/src/features/swf_layer.md
@@ -24,12 +24,6 @@ Settings
 !!! bug
     The informations in this "Settings" section may be outdated, they need some love.
 
-
-Mandatory:
-
-- aws_access_key_id
-- aws_secret_access_key
-
 Optional:
 
 - region
@@ -66,6 +60,8 @@ If neither of the previous methods were used, you can still set the AWS credenti
 [Domain('test1'), Domain('test2')]
 ```
 
+Leaving these AWS API keys unspecified as fine, as Boto's credentials chain
+handler will discovery them if present.
 
 Example usage
 -------------

--- a/docs/src/features/swf_layer.md
+++ b/docs/src/features/swf_layer.md
@@ -60,8 +60,8 @@ If neither of the previous methods were used, you can still set the AWS credenti
 [Domain('test1'), Domain('test2')]
 ```
 
-Leaving these AWS API keys unspecified as fine, as Boto's credentials chain
-handler will discovery them if present.
+Leaving these AWS API keys unspecified is fine, as Boto's credentials chain
+handler will discover them if present.
 
 Example usage
 -------------

--- a/swf/core.py
+++ b/swf/core.py
@@ -42,16 +42,16 @@ class ConnectedSWFObject(object):
                       delay=retry.exponential,
                       on_exceptions=(TypeError, NoAuthHandlerFound))
     def __init__(self, *args, **kwargs):
-        settings_ = {key: SETTINGS.get(key, kwargs.get(key)) for key in
-                     ('aws_access_key_id',
-                      'aws_secret_access_key')}
-
         self.region = (SETTINGS.get('region') or
                        kwargs.get('region') or
                        boto.swf.layer1.Layer1.DefaultRegionName)
-
+        # Use settings-provided keys if available, otherwise pass empty
+        # dictionary to boto SWF client, which will use its default credentials
+        # chain provider.
+        cred_keys = ['aws_access_key_id', 'aws_secret_access_key']
+        creds_ = {k: SETTINGS[k] for k in cred_keys if SETTINGS.get(k, None)}
         self.connection = (kwargs.pop('connection', None) or
-                           boto.swf.connect_to_region(self.region, **settings_))
+                           boto.swf.connect_to_region(self.region, **creds_))
         if self.connection is None:
             raise ValueError('invalid region: {}'.format(self.region))
 

--- a/swf/settings.py
+++ b/swf/settings.py
@@ -149,3 +149,9 @@ def set(**settings):
     """Set settings"""
     from swf.core import SETTINGS
     SETTINGS.update({k: v for k, v in settings.items() if v is not None})
+
+
+def clear():
+    """Clear settings"""
+    from swf.core import SETTINGS
+    SETTINGS.clear()

--- a/swf/settings.py
+++ b/swf/settings.py
@@ -102,18 +102,12 @@ def from_env():
     """Retrieves AWS settings from environment.
 
     Supported environment variables are:
-        - `AWS_ACCESS_KEY_ID`
-        - `AWS_SECRET_ACCESS_KEY`
         - `AWS_DEFAULT_REGION`
 
     :rtype: dict
 
     """
     hsh = {}
-
-    if "AWS_ACCESS_KEY_ID" in os.environ:
-        hsh["aws_access_key_id"] = os.environ["AWS_ACCESS_KEY_ID"]
-        hsh["aws_secret_access_key"] = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
     if "AWS_DEFAULT_REGION" in os.environ:
         hsh["region"] = os.environ["AWS_DEFAULT_REGION"]

--- a/tests/test_swf/test_settings.py
+++ b/tests/test_swf/test_settings.py
@@ -1,15 +1,14 @@
 import os
 import unittest
 
-from swf.core import ConnectedSWFObject
-from swf.settings import from_env
+from swf.core import ConnectedSWFObject, SETTINGS
+from swf.settings import from_env, clear
 
 AWS_ENV_KEYS = (
     "AWS_ACCESS_KEY_ID",
     "AWS_SECRET_ACCESS_KEY",
     "AWS_DEFAULT_REGION",
 )
-
 
 class TestSettings(unittest.TestCase):
     def setUp(self):
@@ -67,6 +66,8 @@ class TestSettings(unittest.TestCase):
         os.environ["AWS_ACCESS_KEY_ID"] = "foo"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "bar"
         os.environ["AWS_SECURITY_TOKEN"] = "baz"
+        # Clear any global settings from other tests.
+        clear()
         obj = ConnectedSWFObject()
         self.assertEqual(obj.connection.aws_access_key_id, "foo")
         self.assertEqual(obj.connection.aws_secret_access_key, "bar")

--- a/tests/test_swf/test_settings.py
+++ b/tests/test_swf/test_settings.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from swf.core import ConnectedSWFObject
 from swf.settings import from_env
 
 AWS_ENV_KEYS = (
@@ -24,18 +25,26 @@ class TestSettings(unittest.TestCase):
             else:
                 os.environ.pop(key, None)
 
+    def test_get_aws_settings_with_region(self):
+        """
+        AWS_DEFAULT_REGION is parsed correctly for settings.
+        """
+        os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
+        _settings = from_env()
+        self.assertEqual(_settings, {
+            "region": "eu-west-1"
+        })
+
     def test_get_aws_settings_with_access_key_id(self):
         """
-        If AWS_ACCESS_KEY_ID is set, get all 3 params from env.
+        Even if AWS_ACCESS_KEY_ID is set in env, don't pass it to settings.
         """
         os.environ["AWS_ACCESS_KEY_ID"] = "foo"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "bar"
         os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
         _settings = from_env()
         self.assertEqual(_settings, {
-            "aws_access_key_id": "foo",
-            "aws_secret_access_key": "bar",
-            "region": "eu-west-1",
+            "region": "eu-west-1"
         })
 
     def test_get_aws_settings_without_access_key_id(self):
@@ -48,3 +57,17 @@ class TestSettings(unittest.TestCase):
         self.assertEqual(from_env(), {
             "region": "eu-west-1",
         })
+
+    def test_get_aws_connection_with_key(self):
+        """
+        If AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and/or AWS_SECURITY_TOKEN
+        are set in environment, they are present in the boto connection.
+
+        """
+        os.environ["AWS_ACCESS_KEY_ID"] = "foo"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "bar"
+        os.environ["AWS_SECURITY_TOKEN"] = "baz"
+        obj = ConnectedSWFObject()
+        self.assertEqual(obj.connection.aws_access_key_id, "foo")
+        self.assertEqual(obj.connection.aws_secret_access_key, "bar")
+        self.assertEqual(obj.connection.provider.security_token, "baz")


### PR DESCRIPTION
Removes explicit handling of AWS keys from the environment, which is
handled by boto2's credentials provider by default. This will also
allow AWS_SECURITY_TOKEN to be handled correctly, which is broken in
the boto2 v2.49 SWF Layer1 client.

Closes https://github.com/botify-labs/simpleflow/issues/346.