### PR TITLE
canvas: support comprehension list in Group

### DIFF
--- a/simpleflow/canvas.py
+++ b/simpleflow/canvas.py
@@ -81,7 +81,10 @@ class Group(SubmittableContainer):
         Tuples are (activity, args).
         """
         for it in iterable:
-            if not isinstance(it, tuple):
+            if isinstance(it, list):
+                for e in it:
+                    self.append(e)
+            elif not isinstance(it, tuple):
                 self.append(it)
             else:
                 self.append(*it)

--- a/tests/test_simpleflow/test_canvas.py
+++ b/tests/test_simpleflow/test_canvas.py
@@ -113,6 +113,12 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(exceptions.ExecutionBlocked):
             future.result
 
+        future = Group(
+            [ActivityTask(to_string, arg=i) for i in range(0, 2)]
+        ).submit(executor)
+        self.assertTrue(future.finished)
+        self.assertEqual(future.result, ["0", "1"])
+
     def test_exceptions(self):
         future = Group(
             (to_string, 1),


### PR DESCRIPTION
Bring support for comprehension list in the Group canvas.

It is now possible to write:

```
Group(
    [ActivityTask(to_string, arg=i) for i in range(0, 2)]
)
```