### PR TITLE
Instrumentation with influxdb backend

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ vcrpy
 wheel
 setuptools
 twine
+influxdb

--- a/swf/actors/worker.py
+++ b/swf/actors/worker.py
@@ -127,6 +127,9 @@ class ActivityWorker(Actor):
                 task_token,
                 format.heartbeat_details(details),
             )
+           # instrumentation
+           self.send_endpoint_usage("RecordActivityTaskHeartbeat")
+ 
         except boto.exception.SWFResponseError as e:
             message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':
@@ -175,6 +178,9 @@ class ActivityWorker(Actor):
                 task_list,
                 identity=format.identity(identity),
             )
+            # instrumentation
+            self.send_endpoint_usage("PollForActivityTask")
+
         except boto.exception.SWFResponseError as e:
             message = self.get_error_message(e)
             if e.error_code == 'UnknownResourceFault':

--- a/swf/core.py
+++ b/swf/core.py
@@ -17,6 +17,9 @@ from simpleflow.utils import retry
 
 from . import settings
 
+# instrumentation
+from influxdb import InfluxDBClient
+
 
 SETTINGS = settings.get()
 RETRIES = int(os.environ.get('SWF_CONNECTION_RETRIES', '5'))
@@ -56,3 +59,12 @@ class ConnectedSWFObject(object):
             raise ValueError('invalid region: {}'.format(self.region))
 
         logger.debug("initiated connection to region={}".format(self.region))
+
+    def send_endpoint_usage(endpoint, host=grafana.botify.com, port=8089):
+        # build the data point
+        # [measurement, tag1, tagn field1 fieldn]
+        # https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#syntax
+        line_body = ["swf,region={}, endpoint={}, swf_call=1".format(self.region, endpoint)]
+        #feed the InfluxDB database with the datapoint
+        client = InfluxDBClient(host, use_udp=True, udp_port=port)
+        client.send_packet(line_body, protocol=u'line')

--- a/swf/core.py
+++ b/swf/core.py
@@ -19,7 +19,7 @@ from . import settings
 
 # instrumentation
 from influxdb import InfluxDBClient
-
+import socket
 
 SETTINGS = settings.get()
 RETRIES = int(os.environ.get('SWF_CONNECTION_RETRIES', '5'))
@@ -60,11 +60,13 @@ class ConnectedSWFObject(object):
 
         logger.debug("initiated connection to region={}".format(self.region))
 
-    def send_endpoint_usage(endpoint, host=grafana.botify.com, port=8089):
+        self.hostname = socket.gethostname()
+
+    def send_endpoint_usage(endpoint, host="grafana.botify.com", port=8089):
         # build the data point
-        # [measurement, tag1, tagn field1 fieldn]
+        # [measurement,tag1,tagn field1 fieldn]
         # https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#syntax
-        line_body = ["swf,region={}, endpoint={}, swf_call=1".format(self.region, endpoint)]
+        line_body = ["swf,region={},endpoint={},hostname={} swf_call=1".format(self.region, endpoint, self.hostname]
         #feed the InfluxDB database with the datapoint
         client = InfluxDBClient(host, use_udp=True, udp_port=port)
         client.send_packet(line_body, protocol=u'line')


### PR DESCRIPTION
### Description
See comments from [this issue](https://botify.atlassian.net/browse/INFRA-1569?atlOrigin=eyJpIjoiZDY4NzA0MTRiNDUzNDBiMjkxMzBhN2NlYTYwZjE4NzMiLCJwIjoiaiJ9) for details about the implementation choice of InfluxDB.

I looked for the 2 endpoints referred in the [issue 298](https://github.com/botify-labs/simpleflow/issues/298)  `RecordActivityTaskHeartbeat` and `PollForActivityTask`, and implement a method inside `swf/core.py` to send statistic to InfluxDB.

I define the [tags](https://docs.influxdata.com/influxdb/v1.7/concepts/glossary/#tag) `region` `endpoint` and `hostname`.

### Considerations for Reviewers
- [This library](https://github.com/influxdata/influxdb-python) is used to talk to InfluxDB backend, I assume [this part of the code](https://github.com/influxdata/influxdb-python/blob/master/influxdb/client.py#L1052) would be non blocking and should not impact the simpleflow behavior, because UDP do not except any answer from the server.

- Maybe we should use some AWS tag instead of the worker hostname (not human friendly)

- Maybe we should pay attention if the worker would not be able to resolve the grafana fqdn.

- Authentication and encryption :

The UDP listener on InfluxDB server doesn't seems to support this, a solutions could consist in writing to a Telegraf proxy agent wich would send the data to Influx over HTTPS.
Or use a local database in the same network.  

### Test environment/Test case
### Considerations for Deployment
In order to implement this solution, the InfluxDB server would have to be setup and the environment secured.
