### PR TITLE
implement influxdb instrumentation

### DIFF
--- a/swf/actors/worker.py
+++ b/swf/actors/worker.py
@@ -123,6 +123,8 @@ class ActivityWorker(Actor):
         :type   details: string
         """
         try:
+            # instrumentation
+            self.send_endpoint_usage("RecordActivityTaskHeartbeat")
             return self.connection.record_activity_task_heartbeat(
                 task_token,
                 format.heartbeat_details(details),
@@ -170,6 +172,8 @@ class ActivityWorker(Actor):
         identity = identity or self._identity
 
         try:
+            # instrumentation
+            self.send_endpoint_usage("PollForActivityTask")
             task = self.connection.poll_for_activity_task(
                 self.domain.name,
                 task_list,

--- a/swf/settings.py
+++ b/swf/settings.py
@@ -76,6 +76,12 @@ def from_stream(stream):
     if config.has_section('defaults'):
         settings['region'] = config.get('defaults', 'region')
 
+    if config.has_section('metrology'):
+        settings.update({
+            'metro_host': config.get('metrology','metro_host'),
+            'metro_port': config.get('metrology','metro_port')
+        })
+
     return settings
 
 


### PR DESCRIPTION
### Description
See comments from [this issue](https://botify.atlassian.net/browse/INFRA-1569?atlOrigin=eyJpIjoiZDY4NzA0MTRiNDUzNDBiMjkxMzBhN2NlYTYwZjE4NzMiLCJwIjoiaiJ9) for details about the implementation choice of InfluxDB.

I looked for the 2 endpoints referred in the [issue 298](https://github.com/botify-labs/simpleflow/issues/298)  `RecordActivityTaskHeartbeat` and `PollForActivityTask`, and implement a method inside `swf/core.py` to send statistic to InfluxDB.

I defined the [tags](https://docs.influxdata.com/influxdb/v1.7/concepts/glossary/#tag) `region` `endpoint` and `hostname`.

### Considerations for Reviewers
- [This library](https://github.com/influxdata/influxdb-python) is used to talk to InfluxDB backend, I assume [this part of the code](https://github.com/influxdata/influxdb-python/blob/master/influxdb/client.py#L1052) would be non blocking and should not impact the simpleflow behavior, because UDP do not except any answer from the server.

- Maybe we should use some AWS tag instead of the worker hostname (not human friendly).

- Authentication and encryption :

The UDP listener on InfluxDB server doesn't seems to support this, a solutions could consist in writing to a Telegraf proxy agent wich would send the data to Influx over HTTPS.
Or use a local database in the same network.  
