### PR TITLE
Add middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Config file for automatic testing at travis-ci.org
+version: ~> 1.0
 
 language: python
 os: linux
@@ -8,14 +9,22 @@ python:
   - "2.7"
   - "3.8"
   - "pypy2"
-  - "pypy3"
 
 install:
-  - pip install .
-  - pip install -r requirements-dev.txt
-  - rm -rf build/
+    - pip install .
+    - pip install -r requirements-dev.txt
+    - rm -rf build/
+
+jobs:
+  include:
+    - language: python
+    - python: "pypy3"
+      install:
+      # cryptography > 3.3 is not currently built for pypy, and we don't want to install rust to build it
+      - pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 cryptography==3.3.1
+      - pip install .
+      - pip install -r requirements-dev.txt
+      - rm -rf build/
+
 
 script: ./script/test -vv
-
-# setting sudo to 'false' allows running on travis-ci new infra (docker)
-sudo: false

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,7 @@ docs_dir: src/
 
 # Project information
 site_name: "Simpleflow documentation"
-copyright: "Copyright &copy; 2017‒2018 — Botify"
+copyright: "Copyright &copy; 2017‒2021 — Botify"
 
 # Code
 repo_name: botify-labs/simpleflow
@@ -11,19 +11,17 @@ repo_url: https://github.com/botify-labs/simpleflow
 edit_uri: edit/master/docs/src/
 
 # Theme / design
-theme: material
-extra:
+theme:
+  name: material
   palette:
-    primary: deep-purple
-    accent: deep-purple
-  feature:
-    tabs: false
+    primary: deep purple
+    accent: deep purple
   social:
-    - type: globe
+    - icon: fontawesome/solid/globe
       link: https://www.botify.com/
-    - type: github-alt
+    - icon: fontawesome/brands/github-alt
       link: https://github.com/botify-labs
-    - type: twitter
+    - icon: fontawesome/brands/twitter
       link: https://twitter.com/botify
 extra_css:
   - stylesheets/extra.css
@@ -31,14 +29,17 @@ extra_css:
 # Extensions
 markdown_extensions:
   - markdown.extensions.admonition
-  - markdown.extensions.codehilite(guess_lang=false)
+  - markdown.extensions.codehilite:
+      guess_lang: False
   - markdown.extensions.def_list
   - markdown.extensions.footnotes
   - markdown.extensions.meta
-  - markdown.extensions.toc(permalink=true)
+  - markdown.extensions.toc:
+      permalink: True
   - markdown_include.include
   - pymdownx.arithmatex
-  - pymdownx.betterem(smart_enable=all)
+  - pymdownx.betterem:
+      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.emoji:
@@ -48,11 +49,12 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences
-  - pymdownx.tasklist(custom_checkbox=true)
+  - pymdownx.tasklist:
+      custom_checkbox: True
   - pymdownx.tilde
 
 # Pages tree
-pages:
+nav:
   - Intro: index.md
   - Installation: installation.md
   - Architecture:
@@ -71,6 +73,7 @@ pages:
       - Task Lists: features/task_lists.md
       - Tags: features/tags.md
       - Error Handling: features/error_handling.md
+      - Middleware: features/middleware.md
   - Development: development.md
   - Contributing: contributing.md
   - License: license.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,23 +4,61 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.human
 #
-backports-abc==0.5        # via tornado
-click==7.1.2              # via mkdocs
-futures==3.3.0            # via tornado
-jinja2==2.11.2            # via mkdocs
-livereload==2.6.2         # via mkdocs
-markdown-include==0.5.1   # via -r requirements.human
-markdown==3.1.1           # via markdown-include, mkdocs, pymdown-extensions
-markupsafe==1.1.1         # via jinja2
-mkdocs-material==1.12.2   # via -r requirements.human
-mkdocs==0.16.3            # via -r requirements.human, mkdocs-material
-pep562==1.0               # via pymdown-extensions
-pygments==2.5.2           # via -r requirements.human, mkdocs-material
-pymdown-extensions==6.2.1  # via -r requirements.human, mkdocs-material
-pyyaml==5.3.1             # via mkdocs
-singledispatch==3.4.0.3   # via tornado
-six==1.15.0               # via livereload
-tornado==5.1.1            # via livereload, mkdocs
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+click==7.1.2
+    # via
+    #   mkdocs
+    #   nltk
+future==0.18.2
+    # via lunr
+jinja2==2.11.2
+    # via mkdocs
+joblib==1.0.1
+    # via nltk
+livereload==2.6.2
+    # via mkdocs
+lunr[languages]==0.5.8
+    # via mkdocs
+markdown-include==0.5.1
+    # via -r requirements.human
+markdown==3.3.3
+    # via
+    #   markdown-include
+    #   mkdocs
+    #   mkdocs-material
+    #   pymdown-extensions
+markupsafe==1.1.1
+    # via jinja2
+mkdocs-material-extensions==1.0.1
+    # via mkdocs-material
+mkdocs-material==6.2.8
+    # via
+    #   -r requirements.human
+    #   mkdocs-material-extensions
+mkdocs==1.1.2
+    # via
+    #   -r requirements.human
+    #   mkdocs-material
+nltk==3.5
+    # via lunr
+pygments==2.5.2
+    # via
+    #   -r requirements.human
+    #   mkdocs-material
+pymdown-extensions==8.1.1
+    # via
+    #   -r requirements.human
+    #   mkdocs-material
+pyyaml==5.3.1
+    # via mkdocs
+regex==2020.11.13
+    # via nltk
+six==1.15.0
+    # via
+    #   livereload
+    #   lunr
+tornado==5.1.1
+    # via
+    #   livereload
+    #   mkdocs
+tqdm==4.56.1
+    # via nltk

--- a/docs/src/features/middleware.md
+++ b/docs/src/features/middleware.md
@@ -1,0 +1,45 @@
+# Middleware
+
+!!! warning
+    This feature is in _beta_ mode and subject to changes. Any feedback is appreciated.
+
+## Presentation
+
+Simpleflow allows for the execution of functions before and after the 
+execution of an Activity.
+
+To do this, you may pass functions as paths when running in standalone 
+mode or when launching a worker (`worker.start` command):
+
+```
+simpleflow standalone
+		--domain TestDomain \
+		--nb-deciders 1 \
+		--nb-workers 1 \
+		--middleware-pre-execution module.path.pre.execution.function \
+		--middleware-pre-execution module.path.pre.execution.second.function \
+		--middleware-post-execution module.path.post.execution.function \
+		myWorkflow \
+		--input '{"args":[], "kwargs": {"task_list":"test"}}'
+```
+
+The above example will execute two functions before each Activity code, 
+and one after.
+
+The `--middleware-pre-execution` and `--middleware-post-execution`
+arguments are also accepted by the `workflow.start` command in
+`--standalone` mode.
+
+## Writing a middleware function
+
+Middleware pre-execution functions receive the activity context. 
+Middleware post-execution functions receive the activity context and
+result.
+
+```
+def my_pre_execution_func(activity_context, **kwargs):
+  pass
+
+def my_post_execution_func(activity_context, result, **kwargs):
+  print("activity result:", "result")
+```

--- a/docs/src/stylesheets/extra.css
+++ b/docs/src/stylesheets/extra.css
@@ -2,16 +2,16 @@
   content: "code";
 }
 .md-typeset {
-  font-size: 1.5rem;
+  font-size: 0.75rem;
 }
 .md-typeset h1 {
-  margin-bottom: 3rem;
+  margin-bottom: 1.5rem;
 }
 .md-typeset h2 {
-  margin-top: 3rem;
+  margin-top: 1.5rem;
 }
 .md-main__inner {
-  padding-top: 1rem;
+  padding-top: 0.5rem;
 }
 .badges {
   display: none;

--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -1,0 +1,6 @@
+def my_pre_execution_middleware(context, **kwargs):
+    print("AAAH PRE EXECUTION MIDDLEWARE", context)
+
+
+def my_post_execution_middleware(context, result, **kwargs):
+    print("AAAH POST EXECUTION MIDDLEWARE", "activity result:", result)

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -12,3 +12,11 @@ echo "FAILING WORKFLOW"
   set -x
   simpleflow workflow.start --local examples.failing.FailingWorkflow --input '[]' 2>&1
 ) | sed "/^ .*/d;s/^Traceback.*/<...snip...>/"
+echo
+echo "WORKFLOW WITH MIDDLEWARE"
+(
+  set -x
+  simpleflow workflow.start --local examples.basic.BasicWorkflow --input '[3, 0]' \
+    --middleware-pre-execution examples.middleware.my_pre_execution_middleware \
+    --middleware-post-execution examples.middleware.my_post_execution_middleware
+)

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -27,7 +27,7 @@ class Executor(executor.Executor):
 
     """
 
-    def __init__(self, workflow_class):
+    def __init__(self, workflow_class, **kwargs):
         super(Executor, self).__init__(workflow_class)
         self.update_workflow_class()
         self.nb_activities = 0
@@ -37,6 +37,8 @@ class Executor(executor.Executor):
         self.wf_run_id = []
         self.wf_id = []
         self._history = None  # type: Optional[Union[builder.History, History]]
+
+        self.middlewares = kwargs.pop("middlewares", None)
 
     @property
     def history(self):
@@ -106,6 +108,7 @@ class Executor(executor.Executor):
             task.context = context
             func = getattr(task, "activity", None)
         elif isinstance(func, Activity):
+            kwargs["simpleflow_middlewares"] = self.middlewares
             task = ActivityTask(func, context=context, *args, **kwargs)
         elif issubclass(func, Workflow):
             task = WorkflowTask(self, func, *args, **kwargs)

--- a/simpleflow/swf/process/worker/command.py
+++ b/simpleflow/swf/process/worker/command.py
@@ -5,7 +5,9 @@ import swf.models
 from .base import ActivityPoller, Worker
 
 
-def make_worker_poller(domain, task_list, heartbeat, process_mode, poll_data):
+def make_worker_poller(
+    domain, task_list, middlewares, heartbeat, process_mode, poll_data
+):
     """
     Make a worker poller for the domain and task list.
     :param domain:
@@ -22,12 +24,15 @@ def make_worker_poller(domain, task_list, heartbeat, process_mode, poll_data):
     :rtype: ActivityPoller
     """
     domain = swf.models.Domain(domain)
-    return ActivityPoller(domain, task_list, heartbeat, process_mode, poll_data)
+    return ActivityPoller(
+        domain, task_list, middlewares, heartbeat, process_mode, poll_data
+    )
 
 
 def start(
     domain,
     task_list,
+    middlewares=None,
     nb_processes=None,
     heartbeat=60,
     one_task=False,
@@ -40,6 +45,8 @@ def start(
     :type domain: str
     :param task_list:
     :type task_list: str
+    :param middlewares: Paths to middleware functions to execute before and after any Activity
+    :type middlewares: Optional[Dict[str, str]]
     :param nb_processes: Number of processes. Default: number of CPUs
     :type nb_processes: Optional[int]
     :param heartbeat: heartbeat frequency in seconds
@@ -51,7 +58,9 @@ def start(
     :param poll_data: Base64 encoded poll data from SWF, in case you don't want to poll directly.
     :type poll_data: Optional[str]
     """
-    poller = make_worker_poller(domain, task_list, heartbeat, process_mode, poll_data)
+    poller = make_worker_poller(
+        domain, task_list, middlewares, heartbeat, process_mode, poll_data
+    )
 
     if poll_data:
         # if "poll_data" is provided, no need to process it multiple times

--- a/tests/integration/test_task_list.py
+++ b/tests/integration/test_task_list.py
@@ -51,6 +51,8 @@ class TestTaskLists(VCRIntegrationTest):
             input="[]",
             input_file=None,
             local=False,
+            middleware_pre_execution=None,
+            middleware_post_execution=None,
         )
         while True:
             time.sleep(1)


### PR DESCRIPTION
This PR adds the loading of a middleware to a simpleflow worker. For simplicity this middleware is then passed to each activity task, effectively allowing us to handle both metrology activities and simple funcs with minimal headaches. 

Leaving the test for another PR as it does not pass on travis for some reason 