### PR TITLE
Fix dumping lazy Proxy object to string in Python 3

### DIFF
--- a/simpleflow/utils/json_tools.py
+++ b/simpleflow/utils/json_tools.py
@@ -35,7 +35,7 @@ def serialize_complex_object(obj):
     elif isinstance(obj, UUID):
         return str(obj)
     elif isinstance(obj, lazy_object_proxy.Proxy):
-        return str(obj)
+        return obj.__wrapped__
     elif isinstance(obj, (set, frozenset)):
         return list(obj)
     raise TypeError(

--- a/tests/test_simpleflow/utils/test_json_dumps.py
+++ b/tests/test_simpleflow/utils/test_json_dumps.py
@@ -76,6 +76,17 @@ class TestJsonDumps(unittest.TestCase):
         actual = json_dumps(data)
         self.assertEqual(expected, actual)
 
+    def test_proxy_dict(self):
+        from lazy_object_proxy import Proxy
+
+        def unwrap():
+            return {"foo": 3}
+
+        data = {"args": [Proxy(unwrap)]}
+        expected = '{"args":[{"foo":3}]}'
+        actual = json_dumps(data)
+        self.assertEqual(expected, actual)
+
     def test_set(self):
         data = [
             {1, 2, 3},


### PR DESCRIPTION
In Python 2, this logic is not called.
In Python 3, no matter the type of the returned object by the Proxy, we convert it to a string,
which is an issue when we expect another type.