### PR TITLE
Revert "Remove obsolete int-to-datetime translation"

### DIFF
--- a/simpleflow/swf/mapper/models/event/base.py
+++ b/simpleflow/swf/mapper/models/event/base.py
@@ -92,7 +92,9 @@ class Event:
 
     @cached_property
     def timestamp(self) -> datetime:
-        return self._timestamp.astimezone(pytz.UTC)
+        if isinstance(self._timestamp, datetime):
+            return self._timestamp.astimezone(pytz.UTC)
+        return datetime.fromtimestamp(self._timestamp, tz=pytz.UTC)
 
     @property
     def input(self) -> dict[str, Any]:


### PR DESCRIPTION
This PR reverts a wrong commit in #423 (never commit something at the last minute :smirk:).

My manual tests showed that timestamps are converted to datetime objects by boto3, but our tests seem to disagree. This PR goes back to green by reverting the commit. I will dig and fix the code and/or the tests later.

NB: I broke the build on "main", so if the tests pass, I will merge right away without a review (I won't be available a lot tomorrow).
