### PR TITLE
chore: setuptools.command.test was removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "pytest",
     "pytest-xdist>=3.2.0",
     "ruff",
+    "setuptools<72", # See https://github.com/pypa/setuptools/issues/4519
     "sphinx",
     "sphinx_rtd_theme",
     "sure",


### PR DESCRIPTION
Temporary “fix” for https://github.com/pypa/setuptools/issues/4519