### PR TITLE
Include stacktrace of exception cause in stacktrace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,26 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9"]
+        include:
+          - os: "ubuntu-22.04"
+            python-version: "3.7"
+          - os: "ubuntu-latest"
+            python-version: "3.8"
+          - os: "ubuntu-latest"
+            python-version: "3.9"
+          - os: "ubuntu-latest"
+            python-version: "3.10"
+          - os: "ubuntu-latest"
+            python-version: "3.11"
+          - os: "ubuntu-latest"
+            python-version: "3.12"
+          - os: "ubuntu-latest"
+            python-version: "3.13"
+          - os: "ubuntu-latest"
+            python-version: "pypy-3.9"
 
     steps:
     - uses: actions/checkout@v3

--- a/simpleflow/local/executor.py
+++ b/simpleflow/local/executor.py
@@ -115,8 +115,8 @@ class Executor(executor.Executor):
                 task.post_execute()
             state = "completed"
         except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            tb = traceback.format_tb(exc_traceback)
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            tb = traceback.format_exception(exc_value, value=exc_value, tb=exc_tb)
             task_failed = exceptions.TaskFailed(
                 name=getattr(task, "name", "unknown"),
                 reason=format_exc(exc_value),

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -152,13 +152,13 @@ class ActivityWorker:
                 **kwargs,
             ).execute()
         except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
+            exc_type, exc_value, exc_tb = sys.exc_info()
             logger.exception(f"process error: {exc_value!s}")
             if isinstance(exc_value, ExecutionError) and len(exc_value.args):
                 details = exc_value.args[0]
                 reason = format_exc(exc_value)  # FIXME json.loads and rebuild?
             else:
-                tb = traceback.format_tb(exc_traceback)
+                tb = traceback.format_exception(exc_value, value=exc_value, tb=exc_tb)
                 reason = format_exc(exc_value)
                 details = json_dumps(
                     {

--- a/tests/test_simpleflow/swf/test_executor.py
+++ b/tests/test_simpleflow/swf/test_executor.py
@@ -200,11 +200,11 @@ class TestSimpleflowSwfExecutorWithJumboFields(MockSWFTestCase):
         activity_result_evt = events[-2]
         assert activity_result_evt["eventType"] == "ActivityTaskFailed"
         attrs = activity_result_evt["activityTaskFailedEventAttributes"]
-        expect(attrs["reason"]).to.match(r"simpleflow\+s3://jumbo-bucket/[a-z0-9-]+ 9\d{4}")
-        expect(attrs["details"]).to.match(r"simpleflow\+s3://jumbo-bucket/[a-z0-9-]+ 9\d{4}")
+        expect(attrs["reason"]).to.match(r"simpleflow\+s3://jumbo-bucket/[a-z0-9-]+ \d{4,}")
+        expect(attrs["details"]).to.match(r"simpleflow\+s3://jumbo-bucket/[a-z0-9-]+ \d{4,}")
         details = format.decode(attrs["details"])
         expect(details["error"]).to.equal("ValueError")
-        expect(len(details["message"])).to.be.greater_than(9 * 10000)
+        expect(len(details["message"])).to.be.greater_than(9 * 10_000)
 
         # decide again (should lead to workflow failure)
         result = self.build_decisions(ExampleJumboWorkflow)


### PR DESCRIPTION
```python
>>> import traceback
>>> try:
...     try:
...         raise ValueError
...     except ValueError as exc:
...         raise IndexError from exc
... except IndexError:
...     import sys
...     exc_type, exc_value, exc_traceback = sys.exc_info()
...     print(traceback.format_tb(exc_traceback))
...
['  File "<python-input-3>", line 5, in <module>\n    raise IndexError from exc\n']
>>> try:
...     try:
...         raise ValueError
...     except ValueError as exc:
...         raise IndexError from exc
... except IndexError:
...     import sys
...     exc_type, exc_value, exc_traceback = sys.exc_info()
...     print(traceback.format_exception(exc_value))
...
['Traceback (most recent call last):\n', '  File "<python-input-5>", line 3, in <module>\n    raise ValueError\n', 'ValueError\n', '\nThe above exception was the direct cause of the following exception:\n\n', 'Traceback (most recent call last):\n', '  File "<python-input-5>", line 5, in <module>\n    raise IndexError from exc\n', 'IndexError\n']
```

As you can see, if we use `traceback.format_exception`, we end up having the full exception, including its causes, whereas with format_tb we only have the last exception which can be far less informative.

This PR makes the exception tracebacks more informative.